### PR TITLE
exclude embed path to avoid deleting

### DIFF
--- a/.github/workflows/cdn_deploy.yml
+++ b/.github/workflows/cdn_deploy.yml
@@ -45,7 +45,8 @@ jobs:
             --exclude "_headers" \
             --exclude "*.mvt" \
             --exclude "dev/embed" --exclude "v1/embed" \
-            --exclude "dev/embed-chunks/*" --exclude "v1/embed-chunks/*"
+            --exclude "dev/embed-chunks/*" --exclude "v1/embed-chunks/*" \
+            --exclude "embed/*"
 
           # Deploy mvt tiles (requires special header for automatic compression)
           # can set max-age to 1 day here because


### PR DESCRIPTION
## Summary
- `s3 sync` で `embed/*`が削除されていた問題を修正

## Checklist (optional)

- [ ] Tests added/updated
- [ ] Docs updated
