### PR TITLE
Add @geolonia/maps-core to CDN

### DIFF
--- a/bin/build-maps-core.sh
+++ b/bin/build-maps-core.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+
+set -ex
+
+npm remove @geolonia/maps-core 2>/dev/null || true
+npm install @geolonia/maps-core -D
+
+mkdir -p ./public/maps-core
+
+rsync -av --exclude '*.d.ts' --exclude '*.d.cts' node_modules/@geolonia/maps-core/dist/ ./public/maps-core/
+cp node_modules/@geolonia/maps-core/src/assets/style.css ./public/maps-core/style.css

--- a/bin/build-maps-core.sh
+++ b/bin/build-maps-core.sh
@@ -2,10 +2,20 @@
 
 set -ex
 
-npm remove @geolonia/maps-core 2>/dev/null || true
-npm install @geolonia/maps-core -D
+# Download UMD bundle from GitHub Release
+REPO="geolonia/maps-core"
+TAG="${MAPS_CORE_VERSION:-latest}"
 
 mkdir -p ./public/maps-core
 
-rsync -av --exclude '*.d.ts' --exclude '*.d.cts' node_modules/@geolonia/maps-core/dist/ ./public/maps-core/
+if [ "$TAG" = "latest" ]; then
+  gh release download --repo "$REPO" --pattern 'maps-core-umd.tar.gz' --dir /tmp --clobber
+else
+  gh release download "$TAG" --repo "$REPO" --pattern 'maps-core-umd.tar.gz' --dir /tmp --clobber
+fi
+
+tar -xzf /tmp/maps-core-umd.tar.gz -C ./public/maps-core/
+
+# CSS is distributed via npm package
+npm install @geolonia/maps-core --ignore-scripts 2>/dev/null || true
 cp node_modules/@geolonia/maps-core/src/assets/style.css ./public/maps-core/style.css

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
       "devDependencies": {
         "@geolonia/embed": "^4.3.0",
         "@geolonia/fixed-map-plugin": "0.0.4",
+        "@geolonia/maps-core": "^0.1.0",
         "@geolonia/view-with-google-plugin": "0.0.2",
         "csv-parse": "^4.12.0",
         "mkdirp": "^1.0.3",
@@ -46,11 +47,159 @@
         "tinycolor2": "^1.4.1"
       }
     },
+    "node_modules/@geolonia/embed/node_modules/@mapbox/vector-tile": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/@mapbox/vector-tile/-/vector-tile-1.3.1.tgz",
+      "integrity": "sha512-MCEddb8u44/xfQ3oD+Srl/tNcQoqTw3goGk2oLsrFxOTc3dUp+kAnby3PvAeeBYSMSjSPD1nd1AJA6W49WnoUw==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@mapbox/point-geometry": "~0.1.0"
+      }
+    },
+    "node_modules/@geolonia/embed/node_modules/@maplibre/maplibre-gl-style-spec": {
+      "version": "19.3.3",
+      "resolved": "https://registry.npmjs.org/@maplibre/maplibre-gl-style-spec/-/maplibre-gl-style-spec-19.3.3.tgz",
+      "integrity": "sha512-cOZZOVhDSulgK0meTsTkmNXb1ahVvmTmWmfx9gRBwc6hq98wS9JP35ESIoNq3xqEan+UN+gn8187Z6E4NKhLsw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "@mapbox/jsonlint-lines-primitives": "~2.0.2",
+        "@mapbox/unitbezier": "^0.0.1",
+        "json-stringify-pretty-compact": "^3.0.0",
+        "minimist": "^1.2.8",
+        "rw": "^1.3.3",
+        "sort-object": "^3.0.3"
+      },
+      "bin": {
+        "gl-style-format": "dist/gl-style-format.mjs",
+        "gl-style-migrate": "dist/gl-style-migrate.mjs",
+        "gl-style-validate": "dist/gl-style-validate.mjs"
+      }
+    },
+    "node_modules/@geolonia/embed/node_modules/earcut": {
+      "version": "2.2.4",
+      "resolved": "https://registry.npmjs.org/earcut/-/earcut-2.2.4.tgz",
+      "integrity": "sha512-/pjZsA1b4RPHbeWZQn66SWS8nZZWLQQ23oE3Eam7aroEFGEvwKAsJfZ9ytiEMycfzXWpca4FA9QIOehf7PocBQ==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/@geolonia/embed/node_modules/json-stringify-pretty-compact": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/json-stringify-pretty-compact/-/json-stringify-pretty-compact-3.0.0.tgz",
+      "integrity": "sha512-Rc2suX5meI0S3bfdZuA7JMFBGkJ875ApfVyq2WHELjBiiG22My/l7/8zPpH/CfFVQHuVLd8NLR0nv6vi0BYYKA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@geolonia/embed/node_modules/maplibre-gl": {
+      "version": "3.4.1",
+      "resolved": "https://registry.npmjs.org/maplibre-gl/-/maplibre-gl-3.4.1.tgz",
+      "integrity": "sha512-RPcdaiZ52G3X+PaHQxqQ1d4I8iTIPRl4OXhPU/3o37kDf+ImLXpUVZj4p0qBCGm71n79daVzaCMG9QxfSSQbnQ==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@mapbox/geojson-rewind": "^0.5.2",
+        "@mapbox/jsonlint-lines-primitives": "^2.0.2",
+        "@mapbox/point-geometry": "^0.1.0",
+        "@mapbox/tiny-sdf": "^2.0.6",
+        "@mapbox/unitbezier": "^0.0.1",
+        "@mapbox/vector-tile": "^1.3.1",
+        "@mapbox/whoots-js": "^3.1.0",
+        "@maplibre/maplibre-gl-style-spec": "^19.3.2",
+        "@types/geojson": "^7946.0.11",
+        "@types/mapbox__point-geometry": "^0.1.2",
+        "@types/mapbox__vector-tile": "^1.3.1",
+        "@types/pbf": "^3.0.3",
+        "@types/supercluster": "^7.1.1",
+        "earcut": "^2.2.4",
+        "geojson-vt": "^3.2.1",
+        "gl-matrix": "^3.4.3",
+        "global-prefix": "^3.0.0",
+        "kdbush": "^4.0.2",
+        "murmurhash-js": "^1.0.0",
+        "pbf": "^3.2.1",
+        "potpack": "^2.0.0",
+        "quickselect": "^2.0.0",
+        "supercluster": "^8.0.1",
+        "tinyqueue": "^2.0.3",
+        "vt-pbf": "^3.1.3"
+      },
+      "engines": {
+        "node": ">=16.14.0",
+        "npm": ">=8.1.0"
+      },
+      "funding": {
+        "url": "https://github.com/maplibre/maplibre-gl-js?sponsor=1"
+      }
+    },
+    "node_modules/@geolonia/embed/node_modules/pbf": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/pbf/-/pbf-3.3.0.tgz",
+      "integrity": "sha512-XDF38WCH3z5OV/OVa8GKUNtLAyneuzbCisx7QUCF8Q6Nutx0WnJrQe5O+kOtBlLfRNUws98Y58Lblp+NJG5T4Q==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "ieee754": "^1.1.12",
+        "resolve-protobuf-schema": "^2.1.0"
+      },
+      "bin": {
+        "pbf": "bin/pbf"
+      }
+    },
+    "node_modules/@geolonia/embed/node_modules/quickselect": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/quickselect/-/quickselect-2.0.0.tgz",
+      "integrity": "sha512-RKJ22hX8mHe3Y6wH/N3wCM6BWtjaxIyyUIkpHOvfFnxdI4yD4tBXEBKSbriGujF6jnSVkJrffuo6vxACiSSxIw==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/@geolonia/embed/node_modules/rw": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/rw/-/rw-1.3.3.tgz",
+      "integrity": "sha512-PdhdWy89SiZogBLaw42zdeqtRJ//zFd2PgQavcICDUgJT5oW10QCRKbJ6bg4r0/UY2M6BWd5tkxuGFRvCkgfHQ==",
+      "dev": true,
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@geolonia/embed/node_modules/tinyqueue": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/tinyqueue/-/tinyqueue-2.0.3.tgz",
+      "integrity": "sha512-ppJZNDuKGgxzkHihX8v9v9G5f+18gzaTfrukGrq6ueg0lmH4nqVnA2IPG0AEH3jKEk2GRJCUhDoqpoiw3PHLBA==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/@geolonia/fixed-map-plugin": {
       "version": "0.0.4",
       "resolved": "https://registry.npmjs.org/@geolonia/fixed-map-plugin/-/fixed-map-plugin-0.0.4.tgz",
       "integrity": "sha512-5RjqF9TjFpAsofD0oba5NZVSFe5lQo1axSrAAwhpQoxfGXOIQcoZOTKjDcDwW6LDdfHbeHyHKmnTCNlOBYjpfQ==",
       "dev": true
+    },
+    "node_modules/@geolonia/maps-core": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/@geolonia/maps-core/-/maps-core-0.1.0.tgz",
+      "integrity": "sha512-k7Tm4/PIDnLX2EL2+9J+hZH+9spo23LWOToYVAmFB8JCR8C1WQJtGlxKe50pGsV5kvn4KkZWwK4KZDGTN30hKg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@geolonia/mbgl-gesture-handling": "^1.0.15",
+        "@mapbox/geojson-extent": "^1.0.0",
+        "@turf/center": "^6.0.1",
+        "pmtiles": "^4.4.0",
+        "sanitize-html": "^2.8.0",
+        "tinycolor2": "^1.4.1"
+      },
+      "peerDependencies": {
+        "maplibre-gl": "^5.0.0"
+      }
+    },
+    "node_modules/@geolonia/maps-core/node_modules/pmtiles": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/pmtiles/-/pmtiles-4.4.0.tgz",
+      "integrity": "sha512-tCLI1C5134MR54i8izUWhse0QUtO/EC33n9yWp1N5dYLLvyc197U0fkF5gAJhq1TdWO9Tvl+9hgvFvM0fR27Zg==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "fflate": "^0.8.2"
+      }
     },
     "node_modules/@geolonia/mbgl-gesture-handling": {
       "version": "1.0.15",
@@ -109,6 +258,7 @@
       "resolved": "https://registry.npmjs.org/@mapbox/geojson-rewind/-/geojson-rewind-0.5.2.tgz",
       "integrity": "sha512-tJaT+RbYGJYStt7wI3cq4Nl4SXxG8W7JDG5DMJu97V25RnbNg3QtQtf+KD+VLjNpWKYsRvXDNmNrBgEETr1ifA==",
       "dev": true,
+      "license": "ISC",
       "dependencies": {
         "get-stream": "^6.0.1",
         "minimist": "^1.2.6"
@@ -133,25 +283,39 @@
       "dev": true
     },
     "node_modules/@mapbox/tiny-sdf": {
-      "version": "2.0.6",
-      "resolved": "https://registry.npmjs.org/@mapbox/tiny-sdf/-/tiny-sdf-2.0.6.tgz",
-      "integrity": "sha512-qMqa27TLw+ZQz5Jk+RcwZGH7BQf5G/TrutJhspsca/3SHwmgKQ1iq+d3Jxz5oysPVYTGP6aXxCo5Lk9Er6YBAA==",
-      "dev": true
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/@mapbox/tiny-sdf/-/tiny-sdf-2.0.7.tgz",
+      "integrity": "sha512-25gQLQMcpivjOSA40g3gO6qgiFPDpWRoMfd+G/GoppPIeP6JDaMMkMrEJnMZhKyyS6iKwVt5YKu02vCUyJM3Ug==",
+      "dev": true,
+      "license": "BSD-2-Clause"
     },
     "node_modules/@mapbox/unitbezier": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/@mapbox/unitbezier/-/unitbezier-0.0.1.tgz",
       "integrity": "sha512-nMkuDXFv60aBr9soUG5q+GvZYL+2KZHVvsqFCzqnkGEf46U2fvmytHaEVc1/YZbiLn8X+eR3QzX1+dwDO1lxlw==",
-      "dev": true
+      "dev": true,
+      "license": "BSD-2-Clause"
     },
     "node_modules/@mapbox/vector-tile": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/@mapbox/vector-tile/-/vector-tile-1.3.1.tgz",
-      "integrity": "sha512-MCEddb8u44/xfQ3oD+Srl/tNcQoqTw3goGk2oLsrFxOTc3dUp+kAnby3PvAeeBYSMSjSPD1nd1AJA6W49WnoUw==",
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/@mapbox/vector-tile/-/vector-tile-2.0.4.tgz",
+      "integrity": "sha512-AkOLcbgGTdXScosBWwmmD7cDlvOjkg/DetGva26pIRiZPdeJYjYKarIlb4uxVzi6bwHO6EWH82eZ5Nuv4T5DUg==",
       "dev": true,
+      "license": "BSD-3-Clause",
+      "peer": true,
       "dependencies": {
-        "@mapbox/point-geometry": "~0.1.0"
+        "@mapbox/point-geometry": "~1.1.0",
+        "@types/geojson": "^7946.0.16",
+        "pbf": "^4.0.1"
       }
+    },
+    "node_modules/@mapbox/vector-tile/node_modules/@mapbox/point-geometry": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@mapbox/point-geometry/-/point-geometry-1.1.0.tgz",
+      "integrity": "sha512-YGcBz1cg4ATXDCM/71L9xveh4dynfGmcLDqufR+nQQy3fKwsAZsWd/x4621/6uJaeB9mwOHE6hPeDgXz9uViUQ==",
+      "dev": true,
+      "license": "ISC",
+      "peer": true
     },
     "node_modules/@mapbox/whoots-js": {
       "version": "3.1.0",
@@ -162,18 +326,32 @@
         "node": ">=6.0.0"
       }
     },
-    "node_modules/@maplibre/maplibre-gl-style-spec": {
-      "version": "19.3.3",
-      "resolved": "https://registry.npmjs.org/@maplibre/maplibre-gl-style-spec/-/maplibre-gl-style-spec-19.3.3.tgz",
-      "integrity": "sha512-cOZZOVhDSulgK0meTsTkmNXb1ahVvmTmWmfx9gRBwc6hq98wS9JP35ESIoNq3xqEan+UN+gn8187Z6E4NKhLsw==",
+    "node_modules/@maplibre/geojson-vt": {
+      "version": "6.0.4",
+      "resolved": "https://registry.npmjs.org/@maplibre/geojson-vt/-/geojson-vt-6.0.4.tgz",
+      "integrity": "sha512-HYv3POhMRCdhP3UPPATM/hfcy6/WuVIf5FKboH8u/ZuFMTnAIcSVlq5nfOqroLokd925w2QtE7YwquFOIacwVQ==",
       "dev": true,
+      "license": "ISC",
+      "peer": true,
+      "dependencies": {
+        "kdbush": "^4.0.2"
+      }
+    },
+    "node_modules/@maplibre/maplibre-gl-style-spec": {
+      "version": "24.7.0",
+      "resolved": "https://registry.npmjs.org/@maplibre/maplibre-gl-style-spec/-/maplibre-gl-style-spec-24.7.0.tgz",
+      "integrity": "sha512-Ed7rcKYU5iELfablg9Mj+TVCsXsPBgdMyXPRAxb2v7oWg9YJnpQdZ5msDs1LESu/mtXy3Z48Vdppv2t/x5kAhw==",
+      "dev": true,
+      "license": "ISC",
+      "peer": true,
       "dependencies": {
         "@mapbox/jsonlint-lines-primitives": "~2.0.2",
         "@mapbox/unitbezier": "^0.0.1",
-        "json-stringify-pretty-compact": "^3.0.0",
+        "json-stringify-pretty-compact": "^4.0.0",
         "minimist": "^1.2.8",
+        "quickselect": "^3.0.0",
         "rw": "^1.3.3",
-        "sort-object": "^3.0.3"
+        "tinyqueue": "^3.0.0"
       },
       "bin": {
         "gl-style-format": "dist/gl-style-format.mjs",
@@ -185,7 +363,61 @@
       "version": "1.3.3",
       "resolved": "https://registry.npmjs.org/rw/-/rw-1.3.3.tgz",
       "integrity": "sha512-PdhdWy89SiZogBLaw42zdeqtRJ//zFd2PgQavcICDUgJT5oW10QCRKbJ6bg4r0/UY2M6BWd5tkxuGFRvCkgfHQ==",
-      "dev": true
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "peer": true
+    },
+    "node_modules/@maplibre/mlt": {
+      "version": "1.1.8",
+      "resolved": "https://registry.npmjs.org/@maplibre/mlt/-/mlt-1.1.8.tgz",
+      "integrity": "sha512-8vtfYGidr1rNkv5IwIoU2lfe3Oy+Wa8HluzQYcQi9cveU9K3pweAal/poQj4GJ0K/EW4bTQp2wVAs09g2yDRZg==",
+      "dev": true,
+      "license": "(MIT OR Apache-2.0)",
+      "peer": true,
+      "dependencies": {
+        "@mapbox/point-geometry": "^1.1.0"
+      }
+    },
+    "node_modules/@maplibre/mlt/node_modules/@mapbox/point-geometry": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@mapbox/point-geometry/-/point-geometry-1.1.0.tgz",
+      "integrity": "sha512-YGcBz1cg4ATXDCM/71L9xveh4dynfGmcLDqufR+nQQy3fKwsAZsWd/x4621/6uJaeB9mwOHE6hPeDgXz9uViUQ==",
+      "dev": true,
+      "license": "ISC",
+      "peer": true
+    },
+    "node_modules/@maplibre/vt-pbf": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/@maplibre/vt-pbf/-/vt-pbf-4.3.0.tgz",
+      "integrity": "sha512-jIvp8F5hQCcreqOOpEt42TJMUlsrEcpf/kI1T2v85YrQRV6PPXUcEXUg5karKtH6oh47XJZ4kHu56pUkOuqA7w==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@mapbox/point-geometry": "^1.1.0",
+        "@mapbox/vector-tile": "^2.0.4",
+        "@maplibre/geojson-vt": "^5.0.4",
+        "@types/geojson": "^7946.0.16",
+        "@types/supercluster": "^7.1.3",
+        "pbf": "^4.0.1",
+        "supercluster": "^8.0.1"
+      }
+    },
+    "node_modules/@maplibre/vt-pbf/node_modules/@mapbox/point-geometry": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@mapbox/point-geometry/-/point-geometry-1.1.0.tgz",
+      "integrity": "sha512-YGcBz1cg4ATXDCM/71L9xveh4dynfGmcLDqufR+nQQy3fKwsAZsWd/x4621/6uJaeB9mwOHE6hPeDgXz9uViUQ==",
+      "dev": true,
+      "license": "ISC",
+      "peer": true
+    },
+    "node_modules/@maplibre/vt-pbf/node_modules/@maplibre/geojson-vt": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/@maplibre/geojson-vt/-/geojson-vt-5.0.4.tgz",
+      "integrity": "sha512-KGg9sma45S+stfH9vPCJk1J0lSDLWZgCT9Y8u8qWZJyjFlP8MNP1WGTxIMYJZjDvVT3PDn05kN1C95Sut1HpgQ==",
+      "dev": true,
+      "license": "ISC",
+      "peer": true
     },
     "node_modules/@turf/bbox": {
       "version": "6.5.0",
@@ -235,22 +467,25 @@
       }
     },
     "node_modules/@types/geojson": {
-      "version": "7946.0.14",
-      "resolved": "https://registry.npmjs.org/@types/geojson/-/geojson-7946.0.14.tgz",
-      "integrity": "sha512-WCfD5Ht3ZesJUsONdhvm84dmzWOiOzOAqOncN0++w0lBw1o8OuDNJF2McvvCef/yBqb/HYRahp1BYtODFQ8bRg==",
-      "dev": true
+      "version": "7946.0.16",
+      "resolved": "https://registry.npmjs.org/@types/geojson/-/geojson-7946.0.16.tgz",
+      "integrity": "sha512-6C8nqWur3j98U6+lXDfTUWIfgvZU+EumvpHKcYjujKH7woYyLj2sUmff0tRhrqM7BohUw7Pz3ZB1jj2gW9Fvmg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/mapbox__point-geometry": {
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/@types/mapbox__point-geometry/-/mapbox__point-geometry-0.1.4.tgz",
       "integrity": "sha512-mUWlSxAmYLfwnRBmgYV86tgYmMIICX4kza8YnE/eIlywGe2XoOxlpVnXWwir92xRLjwyarqwpu2EJKD2pk0IUA==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/mapbox__vector-tile": {
       "version": "1.3.4",
       "resolved": "https://registry.npmjs.org/@types/mapbox__vector-tile/-/mapbox__vector-tile-1.3.4.tgz",
       "integrity": "sha512-bpd8dRn9pr6xKvuEBQup8pwQfD4VUyqO/2deGjfpe6AwC8YRlyEipvefyRJUSiCJTZuCb8Pl1ciVV5ekqJ96Bg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@types/geojson": "*",
         "@types/mapbox__point-geometry": "*",
@@ -261,13 +496,15 @@
       "version": "3.0.5",
       "resolved": "https://registry.npmjs.org/@types/pbf/-/pbf-3.0.5.tgz",
       "integrity": "sha512-j3pOPiEcWZ34R6a6mN07mUkM4o4Lwf6hPNt8eilOeZhTFbxFXmKhvXl9Y28jotFPaI1bpPDJsbCprUoNke6OrA==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/supercluster": {
       "version": "7.1.3",
       "resolved": "https://registry.npmjs.org/@types/supercluster/-/supercluster-7.1.3.tgz",
       "integrity": "sha512-Z0pOY34GDFl3Q6hUFYf3HkTwKEE02e7QgtJppBt+beEAxnyOpJua+voGFvxINBHa06GwLFFym7gRPY2SiKIfIA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@types/geojson": "*"
       }
@@ -277,6 +514,7 @@
       "resolved": "https://registry.npmjs.org/arr-union/-/arr-union-3.1.0.tgz",
       "integrity": "sha512-sKpyeERZ02v1FeCZT8lrfJq5u6goHCtpTAzPwJYe7c8SPFOboNjNg1vz2L4VTn9T4PQxEx13TbXLmYUcS6Ug7Q==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
       }
@@ -324,6 +562,7 @@
       "resolved": "https://registry.npmjs.org/assign-symbols/-/assign-symbols-1.0.0.tgz",
       "integrity": "sha512-Q+JC7Whu8HhmTdBph/Tq59IoRtoy6KAm5zzPv00WdujX82lbAL8K7WVjne7vdCsAmbF4AYaDOPyO3k0kl8qIrw==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
       }
@@ -364,6 +603,7 @@
       "resolved": "https://registry.npmjs.org/bytewise/-/bytewise-1.1.0.tgz",
       "integrity": "sha512-rHuuseJ9iQ0na6UDhnrRVDh8YnWVlU6xM3VH6q/+yHDeUH2zIhUzP+2/h3LIrhLDBtTqzWpE3p3tP/boefskKQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "bytewise-core": "^1.2.2",
         "typewise": "^1.0.3"
@@ -374,6 +614,7 @@
       "resolved": "https://registry.npmjs.org/bytewise-core/-/bytewise-core-1.2.3.tgz",
       "integrity": "sha512-nZD//kc78OOxeYtRlVk8/zXqTB4gf/nlguL1ggWA8FuchMyOxcyHR4QPQZMUmA7czC+YnaBrPUCubqAWe50DaA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "typewise-core": "^1.2"
       }
@@ -559,10 +800,12 @@
       }
     },
     "node_modules/earcut": {
-      "version": "2.2.4",
-      "resolved": "https://registry.npmjs.org/earcut/-/earcut-2.2.4.tgz",
-      "integrity": "sha512-/pjZsA1b4RPHbeWZQn66SWS8nZZWLQQ23oE3Eam7aroEFGEvwKAsJfZ9ytiEMycfzXWpca4FA9QIOehf7PocBQ==",
-      "dev": true
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/earcut/-/earcut-3.0.2.tgz",
+      "integrity": "sha512-X7hshQbLyMJ/3RPhyObLARM2sNxxmRALLKx1+NVFFnQ9gKzmCrxm9+uLIAdBcvc8FNLpctqlQ2V6AE92Ol9UDQ==",
+      "dev": true,
+      "license": "ISC",
+      "peer": true
     },
     "node_modules/entities": {
       "version": "4.5.0",
@@ -717,6 +960,7 @@
       "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
       "integrity": "sha512-zCnTtlxNoAiDc3gqY2aYAWFx7XWWiasuF2K8Me5WbN8otHKTUKBwjPtNpRs/rbUZm7KxWAaNj7P1a/p52GbVug==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "is-extendable": "^0.1.0"
       },
@@ -791,7 +1035,8 @@
       "version": "3.2.1",
       "resolved": "https://registry.npmjs.org/geojson-vt/-/geojson-vt-3.2.1.tgz",
       "integrity": "sha512-EvGQQi/zPrDA6zr6BnJD/YhwAkBP8nnJ9emh3EnHQKVMfg/MRVtPbMYdgVy/IaEmn4UfagD2a6fafPDL5hbtwg==",
-      "dev": true
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/get-intrinsic": {
       "version": "1.2.4",
@@ -817,6 +1062,7 @@
       "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-6.0.1.tgz",
       "integrity": "sha512-ts6Wi+2j3jQjqi70w5AlN8DFnkSwC+MqmxEzdEALB2qXZYV3X/b1CTfgPLGJNMeAWxdPfU8FO1ms3NUfaHCPYg==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=10"
       },
@@ -846,15 +1092,17 @@
       "resolved": "https://registry.npmjs.org/get-value/-/get-value-2.0.6.tgz",
       "integrity": "sha512-Ln0UQDlxH1BapMu3GPtf7CuYNwRZf2gwCuPqbyG6pB8WfmFpzqcy4xtAaAMUhnNqjMKTiCPZG2oMT3YSx8U2NA==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
       }
     },
     "node_modules/gl-matrix": {
-      "version": "3.4.3",
-      "resolved": "https://registry.npmjs.org/gl-matrix/-/gl-matrix-3.4.3.tgz",
-      "integrity": "sha512-wcCp8vu8FT22BnvKVPjXa/ICBWRq/zjFfdofZy1WSpQZpphblv12/bOQLBC1rMM7SGOFS9ltVmKOHil5+Ml7gA==",
-      "dev": true
+      "version": "3.4.4",
+      "resolved": "https://registry.npmjs.org/gl-matrix/-/gl-matrix-3.4.4.tgz",
+      "integrity": "sha512-latSnyDNt/8zYUB6VIJ6PCh2jBjJX6gnDsoCZ7LyW7GkqrD51EWwa9qCoGixj8YqBtETQK/xY7OmpTF8xz1DdQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/glob": {
       "version": "7.1.6",
@@ -878,6 +1126,7 @@
       "resolved": "https://registry.npmjs.org/global-prefix/-/global-prefix-3.0.0.tgz",
       "integrity": "sha512-awConJSVCHVGND6x3tmMaKcQvwXLhjdkmomy2W+Goaui8YPgYgXJZewhg3fWC+DlfqqQuWg8AwqjGTD2nAPVWg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "ini": "^1.3.5",
         "kind-of": "^6.0.2",
@@ -1024,7 +1273,8 @@
           "type": "consulting",
           "url": "https://feross.org/support"
         }
-      ]
+      ],
+      "license": "BSD-3-Clause"
     },
     "node_modules/inflight": {
       "version": "1.0.6",
@@ -1046,7 +1296,8 @@
       "version": "1.3.8",
       "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.8.tgz",
       "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==",
-      "dev": true
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/internal-slot": {
       "version": "1.0.7",
@@ -1153,6 +1404,7 @@
       "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz",
       "integrity": "sha512-5BMULNob1vgFX6EjQw5izWDxrecWK9AM72rugNr0TFldMOi0fj6Jk+zeKIt0xGj4cEfQIJth4w3OKWOJ4f+AFw==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
       }
@@ -1291,69 +1543,71 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
       "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
-      "dev": true
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/isobject": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
       "integrity": "sha512-WhB9zCku7EGTj/HQQRz5aUQEUeoQZH2bWcltRErOpymJ4boYE6wL9Tbr23krRPSZ+C5zqNSrSw+Cc7sZZ4b7vg==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
       }
     },
     "node_modules/json-stringify-pretty-compact": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/json-stringify-pretty-compact/-/json-stringify-pretty-compact-3.0.0.tgz",
-      "integrity": "sha512-Rc2suX5meI0S3bfdZuA7JMFBGkJ875ApfVyq2WHELjBiiG22My/l7/8zPpH/CfFVQHuVLd8NLR0nv6vi0BYYKA==",
-      "dev": true
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/json-stringify-pretty-compact/-/json-stringify-pretty-compact-4.0.0.tgz",
+      "integrity": "sha512-3CNZ2DnrpByG9Nqj6Xo8vqbjT4F6N+tb4Gb28ESAZjYZ5yqvmc56J+/kuIwkaAMOyblTQhUW7PxMkUb8Q36N3Q==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/kdbush": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/kdbush/-/kdbush-4.0.2.tgz",
       "integrity": "sha512-WbCVYJ27Sz8zi9Q7Q0xHC+05iwkm3Znipc2XTlrnJbsHMYktW4hPhXUE8Ys1engBrvffoSCqbil1JQAa7clRpA==",
-      "dev": true
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/kind-of": {
       "version": "6.0.3",
       "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.3.tgz",
       "integrity": "sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
       }
     },
     "node_modules/maplibre-gl": {
-      "version": "3.4.1",
-      "resolved": "https://registry.npmjs.org/maplibre-gl/-/maplibre-gl-3.4.1.tgz",
-      "integrity": "sha512-RPcdaiZ52G3X+PaHQxqQ1d4I8iTIPRl4OXhPU/3o37kDf+ImLXpUVZj4p0qBCGm71n79daVzaCMG9QxfSSQbnQ==",
+      "version": "5.21.1",
+      "resolved": "https://registry.npmjs.org/maplibre-gl/-/maplibre-gl-5.21.1.tgz",
+      "integrity": "sha512-zto1RTnFkOpOO1bm93ElCXF1huey2N4LvXaGLMFcYAu9txh0OhGIdX1q3LZLkrMKgMxMeYduaQo+DVNzg098fg==",
       "dev": true,
+      "license": "BSD-3-Clause",
+      "peer": true,
       "dependencies": {
-        "@mapbox/geojson-rewind": "^0.5.2",
         "@mapbox/jsonlint-lines-primitives": "^2.0.2",
-        "@mapbox/point-geometry": "^0.1.0",
-        "@mapbox/tiny-sdf": "^2.0.6",
+        "@mapbox/point-geometry": "^1.1.0",
+        "@mapbox/tiny-sdf": "^2.0.7",
         "@mapbox/unitbezier": "^0.0.1",
-        "@mapbox/vector-tile": "^1.3.1",
+        "@mapbox/vector-tile": "^2.0.4",
         "@mapbox/whoots-js": "^3.1.0",
-        "@maplibre/maplibre-gl-style-spec": "^19.3.2",
-        "@types/geojson": "^7946.0.11",
-        "@types/mapbox__point-geometry": "^0.1.2",
-        "@types/mapbox__vector-tile": "^1.3.1",
-        "@types/pbf": "^3.0.3",
-        "@types/supercluster": "^7.1.1",
-        "earcut": "^2.2.4",
-        "geojson-vt": "^3.2.1",
-        "gl-matrix": "^3.4.3",
-        "global-prefix": "^3.0.0",
+        "@maplibre/geojson-vt": "^6.0.4",
+        "@maplibre/maplibre-gl-style-spec": "^24.7.0",
+        "@maplibre/mlt": "^1.1.8",
+        "@maplibre/vt-pbf": "^4.3.0",
+        "@types/geojson": "^7946.0.16",
+        "earcut": "^3.0.2",
+        "gl-matrix": "^3.4.4",
         "kdbush": "^4.0.2",
         "murmurhash-js": "^1.0.0",
-        "pbf": "^3.2.1",
-        "potpack": "^2.0.0",
-        "quickselect": "^2.0.0",
-        "supercluster": "^8.0.1",
-        "tinyqueue": "^2.0.3",
-        "vt-pbf": "^3.1.3"
+        "pbf": "^4.0.1",
+        "potpack": "^2.1.0",
+        "quickselect": "^3.0.0",
+        "tinyqueue": "^3.0.0"
       },
       "engines": {
         "node": ">=16.14.0",
@@ -1362,6 +1616,14 @@
       "funding": {
         "url": "https://github.com/maplibre/maplibre-gl-js?sponsor=1"
       }
+    },
+    "node_modules/maplibre-gl/node_modules/@mapbox/point-geometry": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@mapbox/point-geometry/-/point-geometry-1.1.0.tgz",
+      "integrity": "sha512-YGcBz1cg4ATXDCM/71L9xveh4dynfGmcLDqufR+nQQy3fKwsAZsWd/x4621/6uJaeB9mwOHE6hPeDgXz9uViUQ==",
+      "dev": true,
+      "license": "ISC",
+      "peer": true
     },
     "node_modules/minimatch": {
       "version": "3.1.2",
@@ -1380,6 +1642,7 @@
       "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
       "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
       "dev": true,
+      "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
@@ -1504,12 +1767,13 @@
       }
     },
     "node_modules/pbf": {
-      "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/pbf/-/pbf-3.2.1.tgz",
-      "integrity": "sha512-ClrV7pNOn7rtmoQVF4TS1vyU0WhYRnP92fzbfF75jAIwpnzdJXf8iTd4CMEqO4yUenH6NDqLiwjqlh6QgZzgLQ==",
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/pbf/-/pbf-4.0.1.tgz",
+      "integrity": "sha512-SuLdBvS42z33m8ejRbInMapQe8n0D3vN/Xd5fmWM3tufNgRQFBpaW2YVJxQZV4iPNqb0vEFvssMEo5w9c6BTIA==",
       "dev": true,
+      "license": "BSD-3-Clause",
+      "peer": true,
       "dependencies": {
-        "ieee754": "^1.1.12",
         "resolve-protobuf-schema": "^2.1.0"
       },
       "bin": {
@@ -1569,22 +1833,26 @@
       }
     },
     "node_modules/potpack": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/potpack/-/potpack-2.0.0.tgz",
-      "integrity": "sha512-Q+/tYsFU9r7xoOJ+y/ZTtdVQwTWfzjbiXBDMM/JKUux3+QPP02iUuIoeBQ+Ot6oEDlC+/PGjB/5A3K7KKb7hcw==",
-      "dev": true
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/potpack/-/potpack-2.1.0.tgz",
+      "integrity": "sha512-pcaShQc1Shq0y+E7GqJqvZj8DTthWV1KeHGdi0Z6IAin2Oi3JnLCOfwnCo84qc+HAp52wT9nK9H7FAJp5a44GQ==",
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/protocol-buffers-schema": {
       "version": "3.6.0",
       "resolved": "https://registry.npmjs.org/protocol-buffers-schema/-/protocol-buffers-schema-3.6.0.tgz",
       "integrity": "sha512-TdDRD+/QNdrCGCE7v8340QyuXd4kIWIgapsE2+n/SaGiSSbomYl4TjHlvIoCWRpE7wFt02EpB35VVA2ImcBVqw==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/quickselect": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/quickselect/-/quickselect-2.0.0.tgz",
-      "integrity": "sha512-RKJ22hX8mHe3Y6wH/N3wCM6BWtjaxIyyUIkpHOvfFnxdI4yD4tBXEBKSbriGujF6jnSVkJrffuo6vxACiSSxIw==",
-      "dev": true
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/quickselect/-/quickselect-3.0.0.tgz",
+      "integrity": "sha512-XdjUArbK4Bm5fLLvlm5KpTFOiOThgfWWI4axAZDWg4E/0mKdZyI9tNEfds27qCi1ze/vwTR16kvmmGhRra3c2g==",
+      "dev": true,
+      "license": "ISC",
+      "peer": true
     },
     "node_modules/regexp.prototype.flags": {
       "version": "1.5.2",
@@ -1609,6 +1877,7 @@
       "resolved": "https://registry.npmjs.org/resolve-protobuf-schema/-/resolve-protobuf-schema-2.1.0.tgz",
       "integrity": "sha512-kI5ffTiZWmJaS/huM8wZfEMer1eRd7oJQhDuxeCLe3t7N7mX3z94CN0xPxBQxFYQTSNz9T0i+v6inKqSdK8xrQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "protocol-buffers-schema": "^3.3.1"
       }
@@ -1717,6 +1986,7 @@
       "resolved": "https://registry.npmjs.org/set-value/-/set-value-2.0.1.tgz",
       "integrity": "sha512-JxHc1weCN68wRY0fhCoXpyK55m/XPHafOmK4UWD7m2CI14GMcFypt4w/0+NV5f/ZMby2F6S2wwA7fgynh9gWSw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "extend-shallow": "^2.0.1",
         "is-extendable": "^0.1.1",
@@ -1732,6 +2002,7 @@
       "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-2.0.4.tgz",
       "integrity": "sha512-h5PpgXkWitc38BBMYawTYMWJHFZJVnBquFE57xFpjB8pJFiF6gZ+bU+WyI/yqXiFR5mdLsgYNaPe8uao6Uv9Og==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "isobject": "^3.0.1"
       },
@@ -1762,6 +2033,7 @@
       "resolved": "https://registry.npmjs.org/sort-asc/-/sort-asc-0.2.0.tgz",
       "integrity": "sha512-umMGhjPeHAI6YjABoSTrFp2zaBtXBej1a0yKkuMUyjjqu6FJsTF+JYwCswWDg+zJfk/5npWUUbd33HH/WLzpaA==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
       }
@@ -1771,6 +2043,7 @@
       "resolved": "https://registry.npmjs.org/sort-desc/-/sort-desc-0.2.0.tgz",
       "integrity": "sha512-NqZqyvL4VPW+RAxxXnB8gvE1kyikh8+pR+T+CXLksVRN9eiQqkQlPwqWYU0mF9Jm7UnctShlxLyAt1CaBOTL1w==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
       }
@@ -1780,6 +2053,7 @@
       "resolved": "https://registry.npmjs.org/sort-object/-/sort-object-3.0.3.tgz",
       "integrity": "sha512-nK7WOY8jik6zaG9CRwZTaD5O7ETWDLZYMM12pqY8htll+7dYeqGfEUPcUBHOpSJg2vJOrvFIY2Dl5cX2ih1hAQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "bytewise": "^1.1.0",
         "get-value": "^2.0.2",
@@ -1806,6 +2080,7 @@
       "resolved": "https://registry.npmjs.org/split-string/-/split-string-3.1.0.tgz",
       "integrity": "sha512-NzNVhJDYpwceVVii8/Hu6DKfD2G+NrQHlS/V/qgv763EYudVwEcMQNxd2lh+0VrUByXN/oJkl5grOhYWvQUYiw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "extend-shallow": "^3.0.0"
       },
@@ -1818,6 +2093,7 @@
       "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-3.0.2.tgz",
       "integrity": "sha512-BwY5b5Ql4+qZoefgMj2NUmx+tehVTH/Kf4k1ZEtOHNFcm2wSxMRo992l6X3TIgni2eZVTZ85xMOjF31fwZAj6Q==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "assign-symbols": "^1.0.0",
         "is-extendable": "^1.0.1"
@@ -1831,6 +2107,7 @@
       "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-1.0.1.tgz",
       "integrity": "sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "is-plain-object": "^2.0.4"
       },
@@ -1843,6 +2120,7 @@
       "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-2.0.4.tgz",
       "integrity": "sha512-h5PpgXkWitc38BBMYawTYMWJHFZJVnBquFE57xFpjB8pJFiF6gZ+bU+WyI/yqXiFR5mdLsgYNaPe8uao6Uv9Og==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "isobject": "^3.0.1"
       },
@@ -1904,6 +2182,7 @@
       "resolved": "https://registry.npmjs.org/supercluster/-/supercluster-8.0.1.tgz",
       "integrity": "sha512-IiOea5kJ9iqzD2t7QJq/cREyLHTtSmUT6gQsweojg9WH2sYJqZK9SswTu6jrscO6D1G5v5vYZ9ru/eq85lXeZQ==",
       "dev": true,
+      "license": "ISC",
       "dependencies": {
         "kdbush": "^4.0.2"
       }
@@ -1915,10 +2194,12 @@
       "dev": true
     },
     "node_modules/tinyqueue": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/tinyqueue/-/tinyqueue-2.0.3.tgz",
-      "integrity": "sha512-ppJZNDuKGgxzkHihX8v9v9G5f+18gzaTfrukGrq6ueg0lmH4nqVnA2IPG0AEH3jKEk2GRJCUhDoqpoiw3PHLBA==",
-      "dev": true
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/tinyqueue/-/tinyqueue-3.0.0.tgz",
+      "integrity": "sha512-gRa9gwYU3ECmQYv3lslts5hxuIa90veaEcxDYuu3QGOIAEM2mOZkVHp48ANJuu1CURtRdHKUBY5Lm1tHV+sD4g==",
+      "dev": true,
+      "license": "ISC",
+      "peer": true
     },
     "node_modules/tr46": {
       "version": "0.0.3",
@@ -2041,6 +2322,7 @@
       "resolved": "https://registry.npmjs.org/typewise/-/typewise-1.0.3.tgz",
       "integrity": "sha512-aXofE06xGhaQSPzt8hlTY+/YWQhm9P0jYUp1f2XtmW/3Bk0qzXcyFWAtPoo2uTGQj1ZwbDuSyuxicq+aDo8lCQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "typewise-core": "^1.2.0"
       }
@@ -2049,7 +2331,8 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/typewise-core/-/typewise-core-1.2.0.tgz",
       "integrity": "sha512-2SCC/WLzj2SbUwzFOzqMCkz5amXLlxtJqDKTICqg30x+2DZxcfZN2MvQZmGfXWKNWaKK9pBPsvkcwv8bF/gxKg==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/unbox-primitive": {
       "version": "1.0.2",
@@ -2071,6 +2354,7 @@
       "resolved": "https://registry.npmjs.org/union-value/-/union-value-1.0.1.tgz",
       "integrity": "sha512-tJfXmxMeWYnczCVs7XAEvIV7ieppALdyepWMkHkwciRpZraG/xwT+s2JN8+pr1+8jCRf80FFzvr+MpQeeoF4Xg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "arr-union": "^3.1.0",
         "get-value": "^2.0.6",
@@ -2086,10 +2370,35 @@
       "resolved": "https://registry.npmjs.org/vt-pbf/-/vt-pbf-3.1.3.tgz",
       "integrity": "sha512-2LzDFzt0mZKZ9IpVF2r69G9bXaP2Q2sArJCmcCgvfTdCCZzSyz4aCLoQyUilu37Ll56tCblIZrXFIjNUpGIlmA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@mapbox/point-geometry": "0.1.0",
         "@mapbox/vector-tile": "^1.3.1",
         "pbf": "^3.2.1"
+      }
+    },
+    "node_modules/vt-pbf/node_modules/@mapbox/vector-tile": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/@mapbox/vector-tile/-/vector-tile-1.3.1.tgz",
+      "integrity": "sha512-MCEddb8u44/xfQ3oD+Srl/tNcQoqTw3goGk2oLsrFxOTc3dUp+kAnby3PvAeeBYSMSjSPD1nd1AJA6W49WnoUw==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@mapbox/point-geometry": "~0.1.0"
+      }
+    },
+    "node_modules/vt-pbf/node_modules/pbf": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/pbf/-/pbf-3.3.0.tgz",
+      "integrity": "sha512-XDF38WCH3z5OV/OVa8GKUNtLAyneuzbCisx7QUCF8Q6Nutx0WnJrQe5O+kOtBlLfRNUws98Y58Lblp+NJG5T4Q==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "ieee754": "^1.1.12",
+        "resolve-protobuf-schema": "^2.1.0"
+      },
+      "bin": {
+        "pbf": "bin/pbf"
       }
     },
     "node_modules/webidl-conversions": {
@@ -2113,6 +2422,7 @@
       "resolved": "https://registry.npmjs.org/which/-/which-1.3.1.tgz",
       "integrity": "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==",
       "dev": true,
+      "license": "ISC",
       "dependencies": {
         "isexe": "^2.0.0"
       },
@@ -2177,6 +2487,104 @@
         "pmtiles": "2.11.0",
         "sanitize-html": "^2.8.0",
         "tinycolor2": "^1.4.1"
+      },
+      "dependencies": {
+        "@mapbox/vector-tile": {
+          "version": "1.3.1",
+          "resolved": "https://registry.npmjs.org/@mapbox/vector-tile/-/vector-tile-1.3.1.tgz",
+          "integrity": "sha512-MCEddb8u44/xfQ3oD+Srl/tNcQoqTw3goGk2oLsrFxOTc3dUp+kAnby3PvAeeBYSMSjSPD1nd1AJA6W49WnoUw==",
+          "dev": true,
+          "requires": {
+            "@mapbox/point-geometry": "~0.1.0"
+          }
+        },
+        "@maplibre/maplibre-gl-style-spec": {
+          "version": "19.3.3",
+          "resolved": "https://registry.npmjs.org/@maplibre/maplibre-gl-style-spec/-/maplibre-gl-style-spec-19.3.3.tgz",
+          "integrity": "sha512-cOZZOVhDSulgK0meTsTkmNXb1ahVvmTmWmfx9gRBwc6hq98wS9JP35ESIoNq3xqEan+UN+gn8187Z6E4NKhLsw==",
+          "dev": true,
+          "requires": {
+            "@mapbox/jsonlint-lines-primitives": "~2.0.2",
+            "@mapbox/unitbezier": "^0.0.1",
+            "json-stringify-pretty-compact": "^3.0.0",
+            "minimist": "^1.2.8",
+            "rw": "^1.3.3",
+            "sort-object": "^3.0.3"
+          }
+        },
+        "earcut": {
+          "version": "2.2.4",
+          "resolved": "https://registry.npmjs.org/earcut/-/earcut-2.2.4.tgz",
+          "integrity": "sha512-/pjZsA1b4RPHbeWZQn66SWS8nZZWLQQ23oE3Eam7aroEFGEvwKAsJfZ9ytiEMycfzXWpca4FA9QIOehf7PocBQ==",
+          "dev": true
+        },
+        "json-stringify-pretty-compact": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/json-stringify-pretty-compact/-/json-stringify-pretty-compact-3.0.0.tgz",
+          "integrity": "sha512-Rc2suX5meI0S3bfdZuA7JMFBGkJ875ApfVyq2WHELjBiiG22My/l7/8zPpH/CfFVQHuVLd8NLR0nv6vi0BYYKA==",
+          "dev": true
+        },
+        "maplibre-gl": {
+          "version": "3.4.1",
+          "resolved": "https://registry.npmjs.org/maplibre-gl/-/maplibre-gl-3.4.1.tgz",
+          "integrity": "sha512-RPcdaiZ52G3X+PaHQxqQ1d4I8iTIPRl4OXhPU/3o37kDf+ImLXpUVZj4p0qBCGm71n79daVzaCMG9QxfSSQbnQ==",
+          "dev": true,
+          "requires": {
+            "@mapbox/geojson-rewind": "^0.5.2",
+            "@mapbox/jsonlint-lines-primitives": "^2.0.2",
+            "@mapbox/point-geometry": "^0.1.0",
+            "@mapbox/tiny-sdf": "^2.0.6",
+            "@mapbox/unitbezier": "^0.0.1",
+            "@mapbox/vector-tile": "^1.3.1",
+            "@mapbox/whoots-js": "^3.1.0",
+            "@maplibre/maplibre-gl-style-spec": "^19.3.2",
+            "@types/geojson": "^7946.0.11",
+            "@types/mapbox__point-geometry": "^0.1.2",
+            "@types/mapbox__vector-tile": "^1.3.1",
+            "@types/pbf": "^3.0.3",
+            "@types/supercluster": "^7.1.1",
+            "earcut": "^2.2.4",
+            "geojson-vt": "^3.2.1",
+            "gl-matrix": "^3.4.3",
+            "global-prefix": "^3.0.0",
+            "kdbush": "^4.0.2",
+            "murmurhash-js": "^1.0.0",
+            "pbf": "^3.2.1",
+            "potpack": "^2.0.0",
+            "quickselect": "^2.0.0",
+            "supercluster": "^8.0.1",
+            "tinyqueue": "^2.0.3",
+            "vt-pbf": "^3.1.3"
+          }
+        },
+        "pbf": {
+          "version": "3.3.0",
+          "resolved": "https://registry.npmjs.org/pbf/-/pbf-3.3.0.tgz",
+          "integrity": "sha512-XDF38WCH3z5OV/OVa8GKUNtLAyneuzbCisx7QUCF8Q6Nutx0WnJrQe5O+kOtBlLfRNUws98Y58Lblp+NJG5T4Q==",
+          "dev": true,
+          "requires": {
+            "ieee754": "^1.1.12",
+            "resolve-protobuf-schema": "^2.1.0"
+          }
+        },
+        "quickselect": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/quickselect/-/quickselect-2.0.0.tgz",
+          "integrity": "sha512-RKJ22hX8mHe3Y6wH/N3wCM6BWtjaxIyyUIkpHOvfFnxdI4yD4tBXEBKSbriGujF6jnSVkJrffuo6vxACiSSxIw==",
+          "dev": true
+        },
+        "rw": {
+          "version": "1.3.3",
+          "resolved": "https://registry.npmjs.org/rw/-/rw-1.3.3.tgz",
+          "integrity": "sha512-PdhdWy89SiZogBLaw42zdeqtRJ//zFd2PgQavcICDUgJT5oW10QCRKbJ6bg4r0/UY2M6BWd5tkxuGFRvCkgfHQ==",
+          "dev": true
+        },
+        "tinyqueue": {
+          "version": "2.0.3",
+          "resolved": "https://registry.npmjs.org/tinyqueue/-/tinyqueue-2.0.3.tgz",
+          "integrity": "sha512-ppJZNDuKGgxzkHihX8v9v9G5f+18gzaTfrukGrq6ueg0lmH4nqVnA2IPG0AEH3jKEk2GRJCUhDoqpoiw3PHLBA==",
+          "dev": true
+        }
       }
     },
     "@geolonia/fixed-map-plugin": {
@@ -2184,6 +2592,31 @@
       "resolved": "https://registry.npmjs.org/@geolonia/fixed-map-plugin/-/fixed-map-plugin-0.0.4.tgz",
       "integrity": "sha512-5RjqF9TjFpAsofD0oba5NZVSFe5lQo1axSrAAwhpQoxfGXOIQcoZOTKjDcDwW6LDdfHbeHyHKmnTCNlOBYjpfQ==",
       "dev": true
+    },
+    "@geolonia/maps-core": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/@geolonia/maps-core/-/maps-core-0.1.0.tgz",
+      "integrity": "sha512-k7Tm4/PIDnLX2EL2+9J+hZH+9spo23LWOToYVAmFB8JCR8C1WQJtGlxKe50pGsV5kvn4KkZWwK4KZDGTN30hKg==",
+      "dev": true,
+      "requires": {
+        "@geolonia/mbgl-gesture-handling": "^1.0.15",
+        "@mapbox/geojson-extent": "^1.0.0",
+        "@turf/center": "^6.0.1",
+        "pmtiles": "^4.4.0",
+        "sanitize-html": "^2.8.0",
+        "tinycolor2": "^1.4.1"
+      },
+      "dependencies": {
+        "pmtiles": {
+          "version": "4.4.0",
+          "resolved": "https://registry.npmjs.org/pmtiles/-/pmtiles-4.4.0.tgz",
+          "integrity": "sha512-tCLI1C5134MR54i8izUWhse0QUtO/EC33n9yWp1N5dYLLvyc197U0fkF5gAJhq1TdWO9Tvl+9hgvFvM0fR27Zg==",
+          "dev": true,
+          "requires": {
+            "fflate": "^0.8.2"
+          }
+        }
+      }
     },
     "@geolonia/mbgl-gesture-handling": {
       "version": "1.0.15",
@@ -2254,9 +2687,9 @@
       "dev": true
     },
     "@mapbox/tiny-sdf": {
-      "version": "2.0.6",
-      "resolved": "https://registry.npmjs.org/@mapbox/tiny-sdf/-/tiny-sdf-2.0.6.tgz",
-      "integrity": "sha512-qMqa27TLw+ZQz5Jk+RcwZGH7BQf5G/TrutJhspsca/3SHwmgKQ1iq+d3Jxz5oysPVYTGP6aXxCo5Lk9Er6YBAA==",
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/@mapbox/tiny-sdf/-/tiny-sdf-2.0.7.tgz",
+      "integrity": "sha512-25gQLQMcpivjOSA40g3gO6qgiFPDpWRoMfd+G/GoppPIeP6JDaMMkMrEJnMZhKyyS6iKwVt5YKu02vCUyJM3Ug==",
       "dev": true
     },
     "@mapbox/unitbezier": {
@@ -2266,12 +2699,24 @@
       "dev": true
     },
     "@mapbox/vector-tile": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/@mapbox/vector-tile/-/vector-tile-1.3.1.tgz",
-      "integrity": "sha512-MCEddb8u44/xfQ3oD+Srl/tNcQoqTw3goGk2oLsrFxOTc3dUp+kAnby3PvAeeBYSMSjSPD1nd1AJA6W49WnoUw==",
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/@mapbox/vector-tile/-/vector-tile-2.0.4.tgz",
+      "integrity": "sha512-AkOLcbgGTdXScosBWwmmD7cDlvOjkg/DetGva26pIRiZPdeJYjYKarIlb4uxVzi6bwHO6EWH82eZ5Nuv4T5DUg==",
       "dev": true,
+      "peer": true,
       "requires": {
-        "@mapbox/point-geometry": "~0.1.0"
+        "@mapbox/point-geometry": "~1.1.0",
+        "@types/geojson": "^7946.0.16",
+        "pbf": "^4.0.1"
+      },
+      "dependencies": {
+        "@mapbox/point-geometry": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/@mapbox/point-geometry/-/point-geometry-1.1.0.tgz",
+          "integrity": "sha512-YGcBz1cg4ATXDCM/71L9xveh4dynfGmcLDqufR+nQQy3fKwsAZsWd/x4621/6uJaeB9mwOHE6hPeDgXz9uViUQ==",
+          "dev": true,
+          "peer": true
+        }
       }
     },
     "@mapbox/whoots-js": {
@@ -2280,25 +2725,89 @@
       "integrity": "sha512-Es6WcD0nO5l+2BOQS4uLfNPYQaNDfbot3X1XUoloz+x0mPDS3eeORZJl06HXjwBG1fOGwCRnzK88LMdxKRrd6Q==",
       "dev": true
     },
-    "@maplibre/maplibre-gl-style-spec": {
-      "version": "19.3.3",
-      "resolved": "https://registry.npmjs.org/@maplibre/maplibre-gl-style-spec/-/maplibre-gl-style-spec-19.3.3.tgz",
-      "integrity": "sha512-cOZZOVhDSulgK0meTsTkmNXb1ahVvmTmWmfx9gRBwc6hq98wS9JP35ESIoNq3xqEan+UN+gn8187Z6E4NKhLsw==",
+    "@maplibre/geojson-vt": {
+      "version": "6.0.4",
+      "resolved": "https://registry.npmjs.org/@maplibre/geojson-vt/-/geojson-vt-6.0.4.tgz",
+      "integrity": "sha512-HYv3POhMRCdhP3UPPATM/hfcy6/WuVIf5FKboH8u/ZuFMTnAIcSVlq5nfOqroLokd925w2QtE7YwquFOIacwVQ==",
       "dev": true,
+      "peer": true,
+      "requires": {
+        "kdbush": "^4.0.2"
+      }
+    },
+    "@maplibre/maplibre-gl-style-spec": {
+      "version": "24.7.0",
+      "resolved": "https://registry.npmjs.org/@maplibre/maplibre-gl-style-spec/-/maplibre-gl-style-spec-24.7.0.tgz",
+      "integrity": "sha512-Ed7rcKYU5iELfablg9Mj+TVCsXsPBgdMyXPRAxb2v7oWg9YJnpQdZ5msDs1LESu/mtXy3Z48Vdppv2t/x5kAhw==",
+      "dev": true,
+      "peer": true,
       "requires": {
         "@mapbox/jsonlint-lines-primitives": "~2.0.2",
         "@mapbox/unitbezier": "^0.0.1",
-        "json-stringify-pretty-compact": "^3.0.0",
+        "json-stringify-pretty-compact": "^4.0.0",
         "minimist": "^1.2.8",
+        "quickselect": "^3.0.0",
         "rw": "^1.3.3",
-        "sort-object": "^3.0.3"
+        "tinyqueue": "^3.0.0"
       },
       "dependencies": {
         "rw": {
           "version": "1.3.3",
           "resolved": "https://registry.npmjs.org/rw/-/rw-1.3.3.tgz",
           "integrity": "sha512-PdhdWy89SiZogBLaw42zdeqtRJ//zFd2PgQavcICDUgJT5oW10QCRKbJ6bg4r0/UY2M6BWd5tkxuGFRvCkgfHQ==",
-          "dev": true
+          "dev": true,
+          "peer": true
+        }
+      }
+    },
+    "@maplibre/mlt": {
+      "version": "1.1.8",
+      "resolved": "https://registry.npmjs.org/@maplibre/mlt/-/mlt-1.1.8.tgz",
+      "integrity": "sha512-8vtfYGidr1rNkv5IwIoU2lfe3Oy+Wa8HluzQYcQi9cveU9K3pweAal/poQj4GJ0K/EW4bTQp2wVAs09g2yDRZg==",
+      "dev": true,
+      "peer": true,
+      "requires": {
+        "@mapbox/point-geometry": "^1.1.0"
+      },
+      "dependencies": {
+        "@mapbox/point-geometry": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/@mapbox/point-geometry/-/point-geometry-1.1.0.tgz",
+          "integrity": "sha512-YGcBz1cg4ATXDCM/71L9xveh4dynfGmcLDqufR+nQQy3fKwsAZsWd/x4621/6uJaeB9mwOHE6hPeDgXz9uViUQ==",
+          "dev": true,
+          "peer": true
+        }
+      }
+    },
+    "@maplibre/vt-pbf": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/@maplibre/vt-pbf/-/vt-pbf-4.3.0.tgz",
+      "integrity": "sha512-jIvp8F5hQCcreqOOpEt42TJMUlsrEcpf/kI1T2v85YrQRV6PPXUcEXUg5karKtH6oh47XJZ4kHu56pUkOuqA7w==",
+      "dev": true,
+      "peer": true,
+      "requires": {
+        "@mapbox/point-geometry": "^1.1.0",
+        "@mapbox/vector-tile": "^2.0.4",
+        "@maplibre/geojson-vt": "^5.0.4",
+        "@types/geojson": "^7946.0.16",
+        "@types/supercluster": "^7.1.3",
+        "pbf": "^4.0.1",
+        "supercluster": "^8.0.1"
+      },
+      "dependencies": {
+        "@mapbox/point-geometry": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/@mapbox/point-geometry/-/point-geometry-1.1.0.tgz",
+          "integrity": "sha512-YGcBz1cg4ATXDCM/71L9xveh4dynfGmcLDqufR+nQQy3fKwsAZsWd/x4621/6uJaeB9mwOHE6hPeDgXz9uViUQ==",
+          "dev": true,
+          "peer": true
+        },
+        "@maplibre/geojson-vt": {
+          "version": "5.0.4",
+          "resolved": "https://registry.npmjs.org/@maplibre/geojson-vt/-/geojson-vt-5.0.4.tgz",
+          "integrity": "sha512-KGg9sma45S+stfH9vPCJk1J0lSDLWZgCT9Y8u8qWZJyjFlP8MNP1WGTxIMYJZjDvVT3PDn05kN1C95Sut1HpgQ==",
+          "dev": true,
+          "peer": true
         }
       }
     },
@@ -2338,9 +2847,9 @@
       }
     },
     "@types/geojson": {
-      "version": "7946.0.14",
-      "resolved": "https://registry.npmjs.org/@types/geojson/-/geojson-7946.0.14.tgz",
-      "integrity": "sha512-WCfD5Ht3ZesJUsONdhvm84dmzWOiOzOAqOncN0++w0lBw1o8OuDNJF2McvvCef/yBqb/HYRahp1BYtODFQ8bRg==",
+      "version": "7946.0.16",
+      "resolved": "https://registry.npmjs.org/@types/geojson/-/geojson-7946.0.16.tgz",
+      "integrity": "sha512-6C8nqWur3j98U6+lXDfTUWIfgvZU+EumvpHKcYjujKH7woYyLj2sUmff0tRhrqM7BohUw7Pz3ZB1jj2gW9Fvmg==",
       "dev": true
     },
     "@types/mapbox__point-geometry": {
@@ -2581,10 +3090,11 @@
       }
     },
     "earcut": {
-      "version": "2.2.4",
-      "resolved": "https://registry.npmjs.org/earcut/-/earcut-2.2.4.tgz",
-      "integrity": "sha512-/pjZsA1b4RPHbeWZQn66SWS8nZZWLQQ23oE3Eam7aroEFGEvwKAsJfZ9ytiEMycfzXWpca4FA9QIOehf7PocBQ==",
-      "dev": true
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/earcut/-/earcut-3.0.2.tgz",
+      "integrity": "sha512-X7hshQbLyMJ/3RPhyObLARM2sNxxmRALLKx1+NVFFnQ9gKzmCrxm9+uLIAdBcvc8FNLpctqlQ2V6AE92Ol9UDQ==",
+      "dev": true,
+      "peer": true
     },
     "entities": {
       "version": "4.5.0",
@@ -2801,9 +3311,9 @@
       "dev": true
     },
     "gl-matrix": {
-      "version": "3.4.3",
-      "resolved": "https://registry.npmjs.org/gl-matrix/-/gl-matrix-3.4.3.tgz",
-      "integrity": "sha512-wcCp8vu8FT22BnvKVPjXa/ICBWRq/zjFfdofZy1WSpQZpphblv12/bOQLBC1rMM7SGOFS9ltVmKOHil5+Ml7gA==",
+      "version": "3.4.4",
+      "resolved": "https://registry.npmjs.org/gl-matrix/-/gl-matrix-3.4.4.tgz",
+      "integrity": "sha512-latSnyDNt/8zYUB6VIJ6PCh2jBjJX6gnDsoCZ7LyW7GkqrD51EWwa9qCoGixj8YqBtETQK/xY7OmpTF8xz1DdQ==",
       "dev": true
     },
     "glob": {
@@ -3100,10 +3610,11 @@
       "dev": true
     },
     "json-stringify-pretty-compact": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/json-stringify-pretty-compact/-/json-stringify-pretty-compact-3.0.0.tgz",
-      "integrity": "sha512-Rc2suX5meI0S3bfdZuA7JMFBGkJ875ApfVyq2WHELjBiiG22My/l7/8zPpH/CfFVQHuVLd8NLR0nv6vi0BYYKA==",
-      "dev": true
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/json-stringify-pretty-compact/-/json-stringify-pretty-compact-4.0.0.tgz",
+      "integrity": "sha512-3CNZ2DnrpByG9Nqj6Xo8vqbjT4F6N+tb4Gb28ESAZjYZ5yqvmc56J+/kuIwkaAMOyblTQhUW7PxMkUb8Q36N3Q==",
+      "dev": true,
+      "peer": true
     },
     "kdbush": {
       "version": "4.0.2",
@@ -3118,36 +3629,40 @@
       "dev": true
     },
     "maplibre-gl": {
-      "version": "3.4.1",
-      "resolved": "https://registry.npmjs.org/maplibre-gl/-/maplibre-gl-3.4.1.tgz",
-      "integrity": "sha512-RPcdaiZ52G3X+PaHQxqQ1d4I8iTIPRl4OXhPU/3o37kDf+ImLXpUVZj4p0qBCGm71n79daVzaCMG9QxfSSQbnQ==",
+      "version": "5.21.1",
+      "resolved": "https://registry.npmjs.org/maplibre-gl/-/maplibre-gl-5.21.1.tgz",
+      "integrity": "sha512-zto1RTnFkOpOO1bm93ElCXF1huey2N4LvXaGLMFcYAu9txh0OhGIdX1q3LZLkrMKgMxMeYduaQo+DVNzg098fg==",
       "dev": true,
+      "peer": true,
       "requires": {
-        "@mapbox/geojson-rewind": "^0.5.2",
         "@mapbox/jsonlint-lines-primitives": "^2.0.2",
-        "@mapbox/point-geometry": "^0.1.0",
-        "@mapbox/tiny-sdf": "^2.0.6",
+        "@mapbox/point-geometry": "^1.1.0",
+        "@mapbox/tiny-sdf": "^2.0.7",
         "@mapbox/unitbezier": "^0.0.1",
-        "@mapbox/vector-tile": "^1.3.1",
+        "@mapbox/vector-tile": "^2.0.4",
         "@mapbox/whoots-js": "^3.1.0",
-        "@maplibre/maplibre-gl-style-spec": "^19.3.2",
-        "@types/geojson": "^7946.0.11",
-        "@types/mapbox__point-geometry": "^0.1.2",
-        "@types/mapbox__vector-tile": "^1.3.1",
-        "@types/pbf": "^3.0.3",
-        "@types/supercluster": "^7.1.1",
-        "earcut": "^2.2.4",
-        "geojson-vt": "^3.2.1",
-        "gl-matrix": "^3.4.3",
-        "global-prefix": "^3.0.0",
+        "@maplibre/geojson-vt": "^6.0.4",
+        "@maplibre/maplibre-gl-style-spec": "^24.7.0",
+        "@maplibre/mlt": "^1.1.8",
+        "@maplibre/vt-pbf": "^4.3.0",
+        "@types/geojson": "^7946.0.16",
+        "earcut": "^3.0.2",
+        "gl-matrix": "^3.4.4",
         "kdbush": "^4.0.2",
         "murmurhash-js": "^1.0.0",
-        "pbf": "^3.2.1",
-        "potpack": "^2.0.0",
-        "quickselect": "^2.0.0",
-        "supercluster": "^8.0.1",
-        "tinyqueue": "^2.0.3",
-        "vt-pbf": "^3.1.3"
+        "pbf": "^4.0.1",
+        "potpack": "^2.1.0",
+        "quickselect": "^3.0.0",
+        "tinyqueue": "^3.0.0"
+      },
+      "dependencies": {
+        "@mapbox/point-geometry": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/@mapbox/point-geometry/-/point-geometry-1.1.0.tgz",
+          "integrity": "sha512-YGcBz1cg4ATXDCM/71L9xveh4dynfGmcLDqufR+nQQy3fKwsAZsWd/x4621/6uJaeB9mwOHE6hPeDgXz9uViUQ==",
+          "dev": true,
+          "peer": true
+        }
       }
     },
     "minimatch": {
@@ -3238,12 +3753,12 @@
       "dev": true
     },
     "pbf": {
-      "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/pbf/-/pbf-3.2.1.tgz",
-      "integrity": "sha512-ClrV7pNOn7rtmoQVF4TS1vyU0WhYRnP92fzbfF75jAIwpnzdJXf8iTd4CMEqO4yUenH6NDqLiwjqlh6QgZzgLQ==",
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/pbf/-/pbf-4.0.1.tgz",
+      "integrity": "sha512-SuLdBvS42z33m8ejRbInMapQe8n0D3vN/Xd5fmWM3tufNgRQFBpaW2YVJxQZV4iPNqb0vEFvssMEo5w9c6BTIA==",
       "dev": true,
+      "peer": true,
       "requires": {
-        "ieee754": "^1.1.12",
         "resolve-protobuf-schema": "^2.1.0"
       }
     },
@@ -3280,9 +3795,9 @@
       }
     },
     "potpack": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/potpack/-/potpack-2.0.0.tgz",
-      "integrity": "sha512-Q+/tYsFU9r7xoOJ+y/ZTtdVQwTWfzjbiXBDMM/JKUux3+QPP02iUuIoeBQ+Ot6oEDlC+/PGjB/5A3K7KKb7hcw==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/potpack/-/potpack-2.1.0.tgz",
+      "integrity": "sha512-pcaShQc1Shq0y+E7GqJqvZj8DTthWV1KeHGdi0Z6IAin2Oi3JnLCOfwnCo84qc+HAp52wT9nK9H7FAJp5a44GQ==",
       "dev": true
     },
     "protocol-buffers-schema": {
@@ -3292,10 +3807,11 @@
       "dev": true
     },
     "quickselect": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/quickselect/-/quickselect-2.0.0.tgz",
-      "integrity": "sha512-RKJ22hX8mHe3Y6wH/N3wCM6BWtjaxIyyUIkpHOvfFnxdI4yD4tBXEBKSbriGujF6jnSVkJrffuo6vxACiSSxIw==",
-      "dev": true
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/quickselect/-/quickselect-3.0.0.tgz",
+      "integrity": "sha512-XdjUArbK4Bm5fLLvlm5KpTFOiOThgfWWI4axAZDWg4E/0mKdZyI9tNEfds27qCi1ze/vwTR16kvmmGhRra3c2g==",
+      "dev": true,
+      "peer": true
     },
     "regexp.prototype.flags": {
       "version": "1.5.2",
@@ -3552,10 +4068,11 @@
       "dev": true
     },
     "tinyqueue": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/tinyqueue/-/tinyqueue-2.0.3.tgz",
-      "integrity": "sha512-ppJZNDuKGgxzkHihX8v9v9G5f+18gzaTfrukGrq6ueg0lmH4nqVnA2IPG0AEH3jKEk2GRJCUhDoqpoiw3PHLBA==",
-      "dev": true
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/tinyqueue/-/tinyqueue-3.0.0.tgz",
+      "integrity": "sha512-gRa9gwYU3ECmQYv3lslts5hxuIa90veaEcxDYuu3QGOIAEM2mOZkVHp48ANJuu1CURtRdHKUBY5Lm1tHV+sD4g==",
+      "dev": true,
+      "peer": true
     },
     "tr46": {
       "version": "0.0.3",
@@ -3688,6 +4205,27 @@
         "@mapbox/point-geometry": "0.1.0",
         "@mapbox/vector-tile": "^1.3.1",
         "pbf": "^3.2.1"
+      },
+      "dependencies": {
+        "@mapbox/vector-tile": {
+          "version": "1.3.1",
+          "resolved": "https://registry.npmjs.org/@mapbox/vector-tile/-/vector-tile-1.3.1.tgz",
+          "integrity": "sha512-MCEddb8u44/xfQ3oD+Srl/tNcQoqTw3goGk2oLsrFxOTc3dUp+kAnby3PvAeeBYSMSjSPD1nd1AJA6W49WnoUw==",
+          "dev": true,
+          "requires": {
+            "@mapbox/point-geometry": "~0.1.0"
+          }
+        },
+        "pbf": {
+          "version": "3.3.0",
+          "resolved": "https://registry.npmjs.org/pbf/-/pbf-3.3.0.tgz",
+          "integrity": "sha512-XDF38WCH3z5OV/OVa8GKUNtLAyneuzbCisx7QUCF8Q6Nutx0WnJrQe5O+kOtBlLfRNUws98Y58Lblp+NJG5T4Q==",
+          "dev": true,
+          "requires": {
+            "ieee754": "^1.1.12",
+            "resolve-protobuf-schema": "^2.1.0"
+          }
+        }
       }
     },
     "webidl-conversions": {

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "build:tiles": "bash bin/build-tiles.sh",
     "build:styles": "node ./bin/build-styles.js && cp ./styles.json public/style/ && node ./bin/build-sprites.js",
     "build:embed": "bash ./bin/build-embed.sh",
+    "build:maps-core": "bash ./bin/build-maps-core.sh",
     "build:plugins": "bash ./bin/build-plugins.sh",
     "build:geocoder": "curl -H 'Cache-Control: no-cache' https://raw.githubusercontent.com/geolonia/community-geocoder/master/docs/api.js -o public/community-geocoder.js",
     "test": "echo \"Error: no test specified\" && exit 1"
@@ -26,6 +27,7 @@
   "devDependencies": {
     "@geolonia/embed": "^4.3.0",
     "@geolonia/fixed-map-plugin": "0.0.4",
+    "@geolonia/maps-core": "^0.1.0",
     "@geolonia/view-with-google-plugin": "0.0.2",
     "csv-parse": "^4.12.0",
     "mkdirp": "^1.0.3",

--- a/public/maps-core/index.cjs
+++ b/public/maps-core/index.cjs
@@ -1,0 +1,1881 @@
+"use strict";
+var __create = Object.create;
+var __defProp = Object.defineProperty;
+var __getOwnPropDesc = Object.getOwnPropertyDescriptor;
+var __getOwnPropNames = Object.getOwnPropertyNames;
+var __getProtoOf = Object.getPrototypeOf;
+var __hasOwnProp = Object.prototype.hasOwnProperty;
+var __typeError = (msg) => {
+  throw TypeError(msg);
+};
+var __export = (target, all) => {
+  for (var name in all)
+    __defProp(target, name, { get: all[name], enumerable: true });
+};
+var __copyProps = (to, from, except, desc) => {
+  if (from && typeof from === "object" || typeof from === "function") {
+    for (let key of __getOwnPropNames(from))
+      if (!__hasOwnProp.call(to, key) && key !== except)
+        __defProp(to, key, { get: () => from[key], enumerable: !(desc = __getOwnPropDesc(from, key)) || desc.enumerable });
+  }
+  return to;
+};
+var __toESM = (mod, isNodeMode, target) => (target = mod != null ? __create(__getProtoOf(mod)) : {}, __copyProps(
+  // If the importer is in node compatibility mode or this is not an ESM
+  // file that has been converted to a CommonJS file using a Babel-
+  // compatible transform (i.e. "__esModule" has not been set), then set
+  // "default" to the CommonJS "module.exports" for node compatibility.
+  isNodeMode || !mod || !mod.__esModule ? __defProp(target, "default", { value: mod, enumerable: true }) : target,
+  mod
+));
+var __toCommonJS = (mod) => __copyProps(__defProp({}, "__esModule", { value: true }), mod);
+var __accessCheck = (obj, member, msg) => member.has(obj) || __typeError("Cannot " + msg);
+var __privateGet = (obj, member, getter) => (__accessCheck(obj, member, "read from private field"), getter ? getter.call(obj) : member.get(obj));
+var __privateAdd = (obj, member, value) => member.has(obj) ? __typeError("Cannot add the same private member more than once") : member instanceof WeakSet ? member.add(obj) : member.set(obj, value);
+var __privateSet = (obj, member, value, setter) => (__accessCheck(obj, member, "write to private field"), setter ? setter.call(obj, value) : member.set(obj, value), value);
+
+// src/index.ts
+var index_exports = {};
+__export(index_exports, {
+  CustomAttributionControl: () => attribution_default,
+  GeoloniaControl: () => GeoloniaControl,
+  GeoloniaMap: () => GeoloniaMap,
+  GeoloniaMarker: () => GeoloniaMarker,
+  SimpleStyle: () => SimpleStyle,
+  SimpleStyleVector: () => simplestyle_vector_default,
+  coreVersion: () => VERSION,
+  getLang: () => getLang,
+  getStyle: () => getStyle,
+  isGeoloniaTilesHost: () => isGeoloniaTilesHost,
+  keyring: () => keyring
+});
+module.exports = __toCommonJS(index_exports);
+
+// node_modules/@mapbox/point-geometry/index.js
+function Point(x, y) {
+  this.x = x;
+  this.y = y;
+}
+Point.prototype = {
+  /**
+   * Clone this point, returning a new point that can be modified
+   * without affecting the old one.
+   * @return {Point} the clone
+   */
+  clone() {
+    return new Point(this.x, this.y);
+  },
+  /**
+   * Add this point's x & y coordinates to another point,
+   * yielding a new point.
+   * @param {Point} p the other point
+   * @return {Point} output point
+   */
+  add(p) {
+    return this.clone()._add(p);
+  },
+  /**
+   * Subtract this point's x & y coordinates to from point,
+   * yielding a new point.
+   * @param {Point} p the other point
+   * @return {Point} output point
+   */
+  sub(p) {
+    return this.clone()._sub(p);
+  },
+  /**
+   * Multiply this point's x & y coordinates by point,
+   * yielding a new point.
+   * @param {Point} p the other point
+   * @return {Point} output point
+   */
+  multByPoint(p) {
+    return this.clone()._multByPoint(p);
+  },
+  /**
+   * Divide this point's x & y coordinates by point,
+   * yielding a new point.
+   * @param {Point} p the other point
+   * @return {Point} output point
+   */
+  divByPoint(p) {
+    return this.clone()._divByPoint(p);
+  },
+  /**
+   * Multiply this point's x & y coordinates by a factor,
+   * yielding a new point.
+   * @param {number} k factor
+   * @return {Point} output point
+   */
+  mult(k) {
+    return this.clone()._mult(k);
+  },
+  /**
+   * Divide this point's x & y coordinates by a factor,
+   * yielding a new point.
+   * @param {number} k factor
+   * @return {Point} output point
+   */
+  div(k) {
+    return this.clone()._div(k);
+  },
+  /**
+   * Rotate this point around the 0, 0 origin by an angle a,
+   * given in radians
+   * @param {number} a angle to rotate around, in radians
+   * @return {Point} output point
+   */
+  rotate(a) {
+    return this.clone()._rotate(a);
+  },
+  /**
+   * Rotate this point around p point by an angle a,
+   * given in radians
+   * @param {number} a angle to rotate around, in radians
+   * @param {Point} p Point to rotate around
+   * @return {Point} output point
+   */
+  rotateAround(a, p) {
+    return this.clone()._rotateAround(a, p);
+  },
+  /**
+   * Multiply this point by a 4x1 transformation matrix
+   * @param {[number, number, number, number]} m transformation matrix
+   * @return {Point} output point
+   */
+  matMult(m) {
+    return this.clone()._matMult(m);
+  },
+  /**
+   * Calculate this point but as a unit vector from 0, 0, meaning
+   * that the distance from the resulting point to the 0, 0
+   * coordinate will be equal to 1 and the angle from the resulting
+   * point to the 0, 0 coordinate will be the same as before.
+   * @return {Point} unit vector point
+   */
+  unit() {
+    return this.clone()._unit();
+  },
+  /**
+   * Compute a perpendicular point, where the new y coordinate
+   * is the old x coordinate and the new x coordinate is the old y
+   * coordinate multiplied by -1
+   * @return {Point} perpendicular point
+   */
+  perp() {
+    return this.clone()._perp();
+  },
+  /**
+   * Return a version of this point with the x & y coordinates
+   * rounded to integers.
+   * @return {Point} rounded point
+   */
+  round() {
+    return this.clone()._round();
+  },
+  /**
+   * Return the magnitude of this point: this is the Euclidean
+   * distance from the 0, 0 coordinate to this point's x and y
+   * coordinates.
+   * @return {number} magnitude
+   */
+  mag() {
+    return Math.sqrt(this.x * this.x + this.y * this.y);
+  },
+  /**
+   * Judge whether this point is equal to another point, returning
+   * true or false.
+   * @param {Point} other the other point
+   * @return {boolean} whether the points are equal
+   */
+  equals(other) {
+    return this.x === other.x && this.y === other.y;
+  },
+  /**
+   * Calculate the distance from this point to another point
+   * @param {Point} p the other point
+   * @return {number} distance
+   */
+  dist(p) {
+    return Math.sqrt(this.distSqr(p));
+  },
+  /**
+   * Calculate the distance from this point to another point,
+   * without the square root step. Useful if you're comparing
+   * relative distances.
+   * @param {Point} p the other point
+   * @return {number} distance
+   */
+  distSqr(p) {
+    const dx = p.x - this.x, dy = p.y - this.y;
+    return dx * dx + dy * dy;
+  },
+  /**
+   * Get the angle from the 0, 0 coordinate to this point, in radians
+   * coordinates.
+   * @return {number} angle
+   */
+  angle() {
+    return Math.atan2(this.y, this.x);
+  },
+  /**
+   * Get the angle from this point to another point, in radians
+   * @param {Point} b the other point
+   * @return {number} angle
+   */
+  angleTo(b) {
+    return Math.atan2(this.y - b.y, this.x - b.x);
+  },
+  /**
+   * Get the angle between this point and another point, in radians
+   * @param {Point} b the other point
+   * @return {number} angle
+   */
+  angleWith(b) {
+    return this.angleWithSep(b.x, b.y);
+  },
+  /**
+   * Find the angle of the two vectors, solving the formula for
+   * the cross product a x b = |a||b|sin(θ) for θ.
+   * @param {number} x the x-coordinate
+   * @param {number} y the y-coordinate
+   * @return {number} the angle in radians
+   */
+  angleWithSep(x, y) {
+    return Math.atan2(
+      this.x * y - this.y * x,
+      this.x * x + this.y * y
+    );
+  },
+  /** @param {[number, number, number, number]} m */
+  _matMult(m) {
+    const x = m[0] * this.x + m[1] * this.y, y = m[2] * this.x + m[3] * this.y;
+    this.x = x;
+    this.y = y;
+    return this;
+  },
+  /** @param {Point} p */
+  _add(p) {
+    this.x += p.x;
+    this.y += p.y;
+    return this;
+  },
+  /** @param {Point} p */
+  _sub(p) {
+    this.x -= p.x;
+    this.y -= p.y;
+    return this;
+  },
+  /** @param {number} k */
+  _mult(k) {
+    this.x *= k;
+    this.y *= k;
+    return this;
+  },
+  /** @param {number} k */
+  _div(k) {
+    this.x /= k;
+    this.y /= k;
+    return this;
+  },
+  /** @param {Point} p */
+  _multByPoint(p) {
+    this.x *= p.x;
+    this.y *= p.y;
+    return this;
+  },
+  /** @param {Point} p */
+  _divByPoint(p) {
+    this.x /= p.x;
+    this.y /= p.y;
+    return this;
+  },
+  _unit() {
+    this._div(this.mag());
+    return this;
+  },
+  _perp() {
+    const y = this.y;
+    this.y = this.x;
+    this.x = -y;
+    return this;
+  },
+  /** @param {number} angle */
+  _rotate(angle) {
+    const cos = Math.cos(angle), sin = Math.sin(angle), x = cos * this.x - sin * this.y, y = sin * this.x + cos * this.y;
+    this.x = x;
+    this.y = y;
+    return this;
+  },
+  /**
+   * @param {number} angle
+   * @param {Point} p
+   */
+  _rotateAround(angle, p) {
+    const cos = Math.cos(angle), sin = Math.sin(angle), x = p.x + cos * (this.x - p.x) - sin * (this.y - p.y), y = p.y + sin * (this.x - p.x) + cos * (this.y - p.y);
+    this.x = x;
+    this.y = y;
+    return this;
+  },
+  _round() {
+    this.x = Math.round(this.x);
+    this.y = Math.round(this.y);
+    return this;
+  },
+  constructor: Point
+};
+Point.convert = function(p) {
+  if (p instanceof Point) {
+    return (
+      /** @type {Point} */
+      p
+    );
+  }
+  if (Array.isArray(p)) {
+    return new Point(+p[0], +p[1]);
+  }
+  if (p.x !== void 0 && p.y !== void 0) {
+    return new Point(+p.x, +p.y);
+  }
+  throw new Error("Expected [x, y] or {x, y} point format");
+};
+
+// src/lib/maplibre-util.ts
+var _docStyle, _userSelect, _selectProp, _transformProp;
+var _DOM = class _DOM {
+  static testProp(props) {
+    if (!__privateGet(_DOM, _docStyle)) return props[0];
+    for (let i = 0; i < props.length; i++) {
+      if (props[i] in __privateGet(_DOM, _docStyle)) {
+        return props[i];
+      }
+    }
+    return props[0];
+  }
+  static create(tagName, className, container) {
+    const el = window.document.createElement(tagName);
+    if (className !== void 0) el.className = className;
+    if (container) container.appendChild(el);
+    return el;
+  }
+  static createNS(namespaceURI, tagName) {
+    return window.document.createElementNS(namespaceURI, tagName);
+  }
+  static disableDrag() {
+    if (__privateGet(_DOM, _docStyle) && __privateGet(_DOM, _selectProp)) {
+      __privateSet(_DOM, _userSelect, __privateGet(_DOM, _docStyle)[__privateGet(_DOM, _selectProp)]);
+      __privateGet(_DOM, _docStyle)[__privateGet(_DOM, _selectProp)] = "none";
+    }
+  }
+  static enableDrag() {
+    if (__privateGet(_DOM, _docStyle) && __privateGet(_DOM, _selectProp)) {
+      __privateGet(_DOM, _docStyle)[__privateGet(_DOM, _selectProp)] = __privateGet(_DOM, _userSelect) ?? "";
+    }
+  }
+  static setTransform(el, value) {
+    el.style[__privateGet(_DOM, _transformProp)] = value;
+  }
+  static addEventListener(target, type, callback, options) {
+    if ("passive" in options) {
+      target.addEventListener(type, callback, options);
+    } else {
+      target.addEventListener(type, callback, options.capture);
+    }
+  }
+  static removeEventListener(target, type, callback, options) {
+    if ("passive" in options) {
+      target.removeEventListener(type, callback, options);
+    } else {
+      target.removeEventListener(type, callback, options.capture);
+    }
+  }
+  static mousePos(el, e) {
+    const rect = el.getBoundingClientRect();
+    return new Point(
+      e.clientX - rect.left - el.clientLeft,
+      e.clientY - rect.top - el.clientTop
+    );
+  }
+  static touchPos(el, touches) {
+    const rect = el.getBoundingClientRect();
+    const points = [];
+    for (let i = 0; i < touches.length; i++) {
+      points.push(
+        new Point(
+          touches[i].clientX - rect.left - el.clientLeft,
+          touches[i].clientY - rect.top - el.clientTop
+        )
+      );
+    }
+    return points;
+  }
+  static mouseButton(e) {
+    return e.button;
+  }
+  static remove(node) {
+    if (node.parentNode) {
+      node.parentNode.removeChild(node);
+    }
+  }
+};
+_docStyle = new WeakMap();
+_userSelect = new WeakMap();
+_selectProp = new WeakMap();
+_transformProp = new WeakMap();
+__privateAdd(_DOM, _docStyle, typeof window !== "undefined" && window.document && window.document.documentElement.style);
+__privateAdd(_DOM, _userSelect);
+__privateAdd(_DOM, _selectProp, _DOM.testProp([
+  "userSelect",
+  "MozUserSelect",
+  "WebkitUserSelect",
+  "msUserSelect"
+]));
+__privateAdd(_DOM, _transformProp, _DOM.testProp([
+  "transform",
+  "WebkitTransform"
+]));
+var DOM = _DOM;
+function bindAll(fns, context) {
+  for (const fn of fns) {
+    if (typeof context[fn] === "function") {
+      context[fn] = context[fn].bind(
+        context
+      );
+    }
+  }
+}
+
+// src/lib/controls/attribution.ts
+var ATTRIBUTION_CSS = `
+.maplibregl-ctrl {
+  font: 12px/20px Helvetica Neue,Arial,Helvetica,sans-serif;
+  clear: both;
+  pointer-events: auto;
+  transform: translate(0);
+}
+.maplibregl-ctrl-attrib-button:focus,.maplibregl-ctrl-group button:focus {
+  box-shadow: 0 0 2px 2px #0096ff
+}
+.maplibregl-ctrl.maplibregl-ctrl-attrib {
+  background-color: hsla(0,0%,100%,.5);
+  margin: 0;
+  padding: 0 5px
+}
+@media screen {
+  .maplibregl-ctrl-attrib.maplibregl-compact {
+    background-color: #fff;
+    border-radius: 12px;
+    box-sizing: content-box;
+    min-height: 20px;
+    padding: 2px 24px 2px 0;
+    position: relative;
+    margin: 10px 10px 10px auto;
+    width: 0;
+  }
+  .maplibregl-ctrl-attrib.maplibregl-compact-show {
+    padding: 2px 28px 2px 8px;
+    visibility: visible;
+    width: auto;
+  }
+  .maplibregl-ctrl-bottom-left>.maplibregl-ctrl-attrib.maplibregl-compact-show,
+  .maplibregl-ctrl-top-left>.maplibregl-ctrl-attrib.maplibregl-compact-show {
+    border-radius: 12px;
+    padding: 2px 8px 2px 28px
+  }
+  .maplibregl-ctrl-attrib.maplibregl-compact .maplibregl-ctrl-attrib-inner {
+    display: none
+  }
+  .maplibregl-ctrl-attrib-button {
+    background-color: hsla(0,0%,100%,.5);
+    background-image: url("data:image/svg+xml;charset=utf-8,%3Csvg width='24' height='24' viewBox='0 0 20 20' xmlns='http://www.w3.org/2000/svg' fill-rule='evenodd'%3E%3Cpath d='M4 10a6 6 0 1 0 12 0 6 6 0 1 0-12 0m5-3a1 1 0 1 0 2 0 1 1 0 1 0-2 0m0 3a1 1 0 1 1 2 0v3a1 1 0 1 1-2 0'/%3E%3C/svg%3E");
+    border: 0;
+    border-radius: 12px;
+    box-sizing: border-box;
+    cursor: pointer;
+    display: none;
+    height: 24px;
+    outline: none;
+    position: absolute;
+    right: 0;
+    top: 0;
+    width: 24px
+  }
+  .maplibregl-ctrl-attrib summary.maplibregl-ctrl-attrib-button {
+    appearance: none;
+    list-style: none
+  }
+  .maplibregl-ctrl-attrib summary.maplibregl-ctrl-attrib-button::-webkit-details-marker {
+    display: none
+  }
+  .maplibregl-ctrl-bottom-left .maplibregl-ctrl-attrib-button,
+  .maplibregl-ctrl-top-left .maplibregl-ctrl-attrib-button {
+    left: 0
+  }
+  .maplibregl-ctrl-attrib.maplibregl-compact .maplibregl-ctrl-attrib-button,
+  .maplibregl-ctrl-attrib.maplibregl-compact-show .maplibregl-ctrl-attrib-inner {
+    display: block
+  }
+  .maplibregl-ctrl-attrib.maplibregl-compact-show .maplibregl-ctrl-attrib-button {
+    background-color: rgb(0 0 0/5%)
+  }
+  .maplibregl-ctrl-bottom-right>.maplibregl-ctrl-attrib.maplibregl-compact:after {
+    bottom: 0; right: 0
+  }
+  .maplibregl-ctrl-top-right>.maplibregl-ctrl-attrib.maplibregl-compact:after {
+    right: 0; top: 0
+  }
+  .maplibregl-ctrl-top-left>.maplibregl-ctrl-attrib.maplibregl-compact:after {
+    left: 0; top: 0
+  }
+  .maplibregl-ctrl-bottom-left>.maplibregl-ctrl-attrib.maplibregl-compact:after {
+    bottom: 0; left: 0
+  }
+}
+@media screen and (-ms-high-contrast:active) {
+  .maplibregl-ctrl-attrib.maplibregl-compact:after {
+    background-image: url("data:image/svg+xml;charset=utf-8,%3Csvg width='24' height='24' viewBox='0 0 20 20' xmlns='http://www.w3.org/2000/svg' fill-rule='evenodd' fill='%23fff'%3E%3Cpath d='M4 10a6 6 0 1 0 12 0 6 6 0 1 0-12 0m5-3a1 1 0 1 0 2 0 1 1 0 1 0-2 0m0 3a1 1 0 1 1 2 0v3a1 1 0 1 1-2 0'/%3E%3C/svg%3E")
+  }
+}
+@media screen and (-ms-high-contrast:black-on-white) {
+  .maplibregl-ctrl-attrib.maplibregl-compact:after {
+    background-image: url("data:image/svg+xml;charset=utf-8,%3Csvg width='24' height='24' viewBox='0 0 20 20' xmlns='http://www.w3.org/2000/svg' fill-rule='evenodd'%3E%3Cpath d='M4 10a6 6 0 1 0 12 0 6 6 0 1 0-12 0m5-3a1 1 0 1 0 2 0 1 1 0 1 0-2 0m0 3a1 1 0 1 1 2 0v3a1 1 0 1 1-2 0'/%3E%3C/svg%3E")
+  }
+}
+@media print {
+  .maplibregl-ctrl-attrib-button {
+    display: none !important;
+  }
+}
+.maplibregl-ctrl-attrib a {
+  color: rgba(0,0,0,.75);
+  text-decoration: none;
+  white-space: nowrap;
+}
+.maplibregl-ctrl-attrib a:hover {
+  color: inherit;
+  text-decoration: underline
+}
+.maplibregl-attrib-empty {
+  display: none
+}
+`;
+var CustomAttributionControl = class {
+  constructor(options = {}) {
+    this._editLink = null;
+    this.options = options;
+    bindAll(
+      [
+        "_toggleAttribution",
+        "_updateData",
+        "_updateCompact",
+        "_updateCompactMinimize"
+      ],
+      this
+    );
+  }
+  getDefaultPosition() {
+    return "bottom-right";
+  }
+  onAdd(map) {
+    this._map = map;
+    this._compact = this.options.compact;
+    this._container = DOM.create("div");
+    const shadow = this._container.attachShadow({ mode: "open" });
+    this._shadowContainer = DOM.create(
+      "details",
+      "maplibregl-ctrl maplibregl-ctrl-attrib"
+    );
+    this._compactButton = DOM.create(
+      "summary",
+      "maplibregl-ctrl-attrib-button",
+      this._shadowContainer
+    );
+    this._compactButton.addEventListener("click", this._toggleAttribution);
+    this._setElementTitle(this._compactButton, "ToggleAttribution");
+    this._innerContainer = DOM.create(
+      "div",
+      "maplibregl-ctrl-attrib-inner",
+      this._shadowContainer
+    );
+    const style = document.createElement("style");
+    style.textContent = ATTRIBUTION_CSS;
+    this._updateAttributions();
+    this._updateCompact();
+    this._map.on("styledata", this._updateData);
+    this._map.on("sourcedata", this._updateData);
+    this._map.on("terrain", this._updateData);
+    this._map.on("resize", this._updateCompact);
+    this._map.on("drag", this._updateCompactMinimize);
+    shadow.appendChild(style);
+    shadow.appendChild(this._shadowContainer);
+    this.printQuery = window.matchMedia("print");
+    this.onMediaPrintChange = (e) => {
+      if (e.matches) {
+        this._shadowContainer.setAttribute("open", "");
+        this._shadowContainer.classList.remove("maplibregl-compact-show");
+      }
+    };
+    this.printQuery.addEventListener("change", this.onMediaPrintChange);
+    return this._container;
+  }
+  onRemove() {
+    if (this._container) {
+      DOM.remove(this._container);
+    }
+    if (this._map) {
+      this._map.off("styledata", this._updateData);
+      this._map.off("sourcedata", this._updateData);
+      this._map.off("terrain", this._updateData);
+      this._map.off("resize", this._updateCompact);
+      this._map.off("drag", this._updateCompactMinimize);
+    }
+    if (this.printQuery && this.onMediaPrintChange) {
+      this.printQuery.removeEventListener("change", this.onMediaPrintChange);
+    }
+    this._map = void 0;
+    this._compact = void 0;
+    this._attribHTML = void 0;
+  }
+  _setElementTitle(element, title) {
+    if (!this._map) return;
+    const str = this._map._getUIString(`AttributionControl.${title}`);
+    element.title = str;
+    element.setAttribute("aria-label", str);
+  }
+  _toggleAttribution() {
+    if (!this._shadowContainer) return;
+    if (this._shadowContainer.classList.contains("maplibregl-compact")) {
+      if (this._shadowContainer.classList.contains("maplibregl-compact-show")) {
+        this._shadowContainer.setAttribute("open", "");
+        this._shadowContainer.classList.remove("maplibregl-compact-show");
+      } else {
+        this._shadowContainer.classList.add("maplibregl-compact-show");
+        this._shadowContainer.removeAttribute("open");
+      }
+    }
+  }
+  _updateData(e) {
+    if (e && (e.sourceDataType === "metadata" || e.sourceDataType === "visibility" || e.dataType === "style" || e.type === "terrain")) {
+      this._updateAttributions();
+    }
+  }
+  _updateAttributions() {
+    if (!this._map || !this._map.style) return;
+    let attributions = [];
+    if (this.options.customAttribution) {
+      if (Array.isArray(this.options.customAttribution)) {
+        attributions = attributions.concat(
+          this.options.customAttribution.filter(
+            (attr) => typeof attr === "string"
+          )
+        );
+      } else if (typeof this.options.customAttribution === "string") {
+        attributions.push(this.options.customAttribution);
+      }
+    }
+    if (this._map.style.stylesheet) {
+      const stylesheet = this._map.style.stylesheet;
+      this.styleOwner = stylesheet.owner;
+      this.styleId = stylesheet.id;
+    }
+    const sourceCaches = this._map.style.sourceCaches;
+    for (const id in sourceCaches) {
+      const sourceCache = sourceCaches[id];
+      if (sourceCache.used || sourceCache.usedForTerrain) {
+        const source = sourceCache.getSource();
+        if (source.attribution && attributions.indexOf(source.attribution) < 0) {
+          attributions.push(source.attribution);
+        }
+      }
+    }
+    attributions = attributions.filter((e) => String(e).trim());
+    attributions.sort((a, b) => a.length - b.length);
+    attributions = attributions.filter((attrib, i) => {
+      for (let j = i + 1; j < attributions.length; j++) {
+        if (attributions[j].indexOf(attrib) >= 0) {
+          return false;
+        }
+      }
+      return true;
+    });
+    const attribHTML = attributions.join(" | ");
+    if (attribHTML === this._attribHTML) return;
+    this._attribHTML = attribHTML;
+    if (attributions.length) {
+      this._innerContainer.innerHTML = attribHTML;
+      this._shadowContainer.classList.remove("maplibregl-attrib-empty");
+    } else {
+      this._shadowContainer.classList.add("maplibregl-attrib-empty");
+    }
+    this._updateCompact();
+    this._editLink = null;
+  }
+  _updateCompact() {
+    if (!this._map || !this._shadowContainer) return;
+    if (this._map.getCanvasContainer().offsetWidth <= 640 || this._compact) {
+      if (this._compact === false) {
+        this._shadowContainer.setAttribute("open", "");
+      } else if (!this._shadowContainer.classList.contains("maplibregl-compact") && !this._shadowContainer.classList.contains("maplibregl-attrib-empty")) {
+        this._shadowContainer.setAttribute("open", "");
+        this._shadowContainer.classList.add(
+          "maplibregl-compact",
+          "maplibregl-compact-show"
+        );
+      }
+    } else {
+      this._shadowContainer.setAttribute("open", "");
+      if (this._shadowContainer.classList.contains("maplibregl-compact")) {
+        this._shadowContainer.classList.remove(
+          "maplibregl-compact",
+          "maplibregl-compact-show"
+        );
+      }
+    }
+  }
+  _updateCompactMinimize() {
+    if (!this._shadowContainer) return;
+    if (this._shadowContainer.classList.contains("maplibregl-compact")) {
+      if (this._shadowContainer.classList.contains("maplibregl-compact-show")) {
+        this._shadowContainer.classList.remove("maplibregl-compact-show");
+      }
+    }
+  }
+};
+var attribution_default = CustomAttributionControl;
+
+// src/lib/controls/geolonia-logo.ts
+var GeoloniaControl = class {
+  onAdd() {
+    this.container = document.createElement("div");
+    this.container.className = "maplibregl-ctrl";
+    const img = document.createElement("img");
+    img.src = "https://cdn.geolonia.com/logo/geolonia-symbol_1.png";
+    img.style.width = "16px";
+    img.style.height = "16px";
+    img.style.display = "block";
+    img.style.cursor = "pointer";
+    img.style.padding = "0";
+    img.style.margin = "0";
+    img.style.border = "none";
+    img.alt = "Geolonia";
+    const link = document.createElement("a");
+    link.href = "https://geolonia.com/";
+    link.appendChild(img);
+    link.title = "Powered by Geolonia";
+    this.container.appendChild(link);
+    return this.container;
+  }
+  onRemove() {
+    this.container.parentNode?.removeChild(this.container);
+  }
+  getDefaultPosition() {
+    return "bottom-left";
+  }
+};
+
+// src/lib/geolonia-map.ts
+var import_maplibre_gl4 = __toESM(require("maplibre-gl"), 1);
+var import_pmtiles = require("pmtiles");
+
+// src/lib/geolonia-marker.ts
+var import_maplibre_gl = __toESM(require("maplibre-gl"), 1);
+var import_tinycolor2 = __toESM(require("tinycolor2"), 1);
+var MARKER_SVG = `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 52 67">
+  <path class="left" d="M26 0C11.664 0 0 11.663 0 26c0 22.14 26 41 26 41V26h0C26 11.663 26 0 26 0z" fill="#E4402F"/>
+  <path class="right" d="M26 0c14.336 0 26 11.663 26 26 0 22.14-26 41-26 41V26h0C26 11.663 26 0 26 0z" fill="#C1272D"/>
+  <circle cx="26" cy="26" r="9" fill="#FFF"/>
+</svg>`;
+var DEFAULT_COLOR = "#E4402F";
+var GeoloniaMarker = class extends import_maplibre_gl.default.Marker {
+  constructor(options = {}) {
+    if (!options.element) {
+      const markerElement = document.createElement("div");
+      markerElement.className = "geolonia-default-marker";
+      markerElement.innerHTML = MARKER_SVG;
+      markerElement.style.margin = "0";
+      markerElement.style.padding = "0";
+      markerElement.style.width = "26px";
+      markerElement.style.height = "34px";
+      const svg = markerElement.querySelector("svg");
+      if (svg) {
+        svg.style.width = "100%";
+        svg.style.height = "100%";
+      }
+      options.element = markerElement;
+      const color = options.color || DEFAULT_COLOR;
+      const left = markerElement.querySelector(".left");
+      const right = markerElement.querySelector(".right");
+      if (left) left.style.fill = color;
+      if (right) right.style.fill = (0, import_tinycolor2.default)(color).darken().toString();
+      options.offset = [0, -15];
+    }
+    super(options);
+  }
+};
+
+// src/lib/simplestyle.ts
+var import_geojson_extent = __toESM(require("@mapbox/geojson-extent"), 1);
+var import_center = __toESM(require("@turf/center"), 1);
+var import_maplibre_gl2 = __toESM(require("maplibre-gl"), 1);
+
+// src/lib/keyring.ts
+var _apiKey, _stage, _isGeoloniaStyle;
+var Keyring = class {
+  constructor() {
+    __privateAdd(this, _apiKey, "");
+    __privateAdd(this, _stage, "dev");
+    __privateAdd(this, _isGeoloniaStyle, true);
+  }
+  get apiKey() {
+    return __privateGet(this, _apiKey);
+  }
+  get stage() {
+    return __privateGet(this, _stage);
+  }
+  get isGeoloniaStyle() {
+    return __privateGet(this, _isGeoloniaStyle);
+  }
+  set isGeoloniaStyle(value) {
+    __privateSet(this, _isGeoloniaStyle, value);
+  }
+  setApiKey(key) {
+    __privateSet(this, _apiKey, key);
+  }
+  setStage(stage) {
+    __privateSet(this, _stage, stage);
+  }
+  reset() {
+    __privateSet(this, _apiKey, "");
+    __privateSet(this, _stage, "dev");
+    __privateSet(this, _isGeoloniaStyle, true);
+  }
+  /**
+   * Check if the given style is a Geolonia style (requires API key)
+   */
+  isGeoloniaStyleCheck(style) {
+    if (!style || style === "") {
+      return true;
+    }
+    if (style.startsWith("https://cdn.geolonia.com/style/") || style.startsWith("https://api.geolonia.com/")) {
+      return true;
+    }
+    if (style.match(/^https?:\/\//)) {
+      return false;
+    }
+    if (style.endsWith(".json")) {
+      return false;
+    }
+    return true;
+  }
+};
+_apiKey = new WeakMap();
+_stage = new WeakMap();
+_isGeoloniaStyle = new WeakMap();
+var keyring = new Keyring();
+
+// src/lib/util.ts
+function isURL(str) {
+  if (str.match(/^https?:\/\//)) {
+    return str;
+  }
+  if (str.match(/^\//) || str.match(/^\.\.?/)) {
+    try {
+      return new URL(str, globalThis.location?.href).href;
+    } catch {
+      return false;
+    }
+  }
+  return false;
+}
+function isGeoloniaTilesHost(url) {
+  try {
+    const urlObj = typeof url === "string" ? new URL(url) : url;
+    return urlObj.hostname === "tileserver.geolonia.com" || urlObj.hostname.endsWith(".tiles.geolonia.com");
+  } catch {
+    return false;
+  }
+}
+function getStyle(style, options) {
+  const lang = options.lang || "en";
+  const apiKey = options.apiKey || keyring.apiKey;
+  if (keyring.isGeoloniaStyleCheck(style) && !apiKey) {
+    throw new Error("[Geolonia] API key is required to use Geolonia styles.");
+  }
+  if (!style || style === "") {
+    return `https://cdn.geolonia.com/style/geolonia/basic-v2/${lang === "ja" ? "ja" : "en"}.json`;
+  }
+  const styleUrl = isURL(style);
+  if (styleUrl) {
+    return styleUrl;
+  }
+  if (style.endsWith(".json")) {
+    try {
+      return new URL(style, globalThis.location?.href).href;
+    } catch {
+      return style;
+    }
+  }
+  return `https://cdn.geolonia.com/style/${style}/${lang === "ja" ? "ja" : "en"}.json`;
+}
+function getLang() {
+  if (typeof globalThis.navigator === "undefined") {
+    return "en";
+  }
+  const lang = globalThis.navigator.languages?.[0]?.toLowerCase() || globalThis.navigator.language?.toLowerCase();
+  return lang === "ja" || lang === "ja-jp" ? "ja" : "en";
+}
+var sessionId = "";
+function getSessionId(digit) {
+  if (sessionId) {
+    return sessionId;
+  }
+  const array = new Uint8Array(digit / 2);
+  crypto.getRandomValues(array);
+  sessionId = Array.from(
+    array,
+    (dec) => dec.toString(16).padStart(2, "0")
+  ).join("");
+  return sessionId;
+}
+function parseControlOption(value) {
+  if (typeof value === "boolean") {
+    return { enabled: value, position: void 0 };
+  }
+  if (typeof value === "string") {
+    const positions = ["top-right", "bottom-right", "bottom-left", "top-left"];
+    if (positions.includes(value.toLowerCase())) {
+      return { enabled: true, position: value.toLowerCase() };
+    }
+  }
+  return { enabled: false, position: void 0 };
+}
+function parseSimpleVector(attributeValue) {
+  if (/^(https?|geolonia):\/\//.test(attributeValue)) {
+    return attributeValue;
+  }
+  return `geolonia://tiles/custom/${attributeValue}`;
+}
+function handleRestrictedMode(map) {
+  if (!map._geolonia_restricted_mode_handled) {
+    map._geolonia_restricted_mode_handled = true;
+    const container = map.getContainer();
+    map.remove();
+    container.innerHTML = "";
+    container.classList.add("geolonia__restricted-mode-image-container");
+  }
+}
+function handleErrorMode(container) {
+  const errorContainer = document.createElement("div");
+  errorContainer.classList.add("geolonia__error-container");
+  const div = document.createElement("div");
+  const h2 = document.createElement("h2");
+  h2.textContent = "Geolonia Maps";
+  div.appendChild(h2);
+  div.classList.add("geolonia__error-message");
+  div.innerHTML += '<div class="geolonia__error-message-description">\u5730\u56F3\u306E\u521D\u671F\u5316\u306B\u5931\u6557\u3057\u307E\u3057\u305F\u3002\u7BA1\u7406\u8005\u306B\u304A\u554F\u3044\u5408\u308F\u305B\u4E0B\u3055\u3044\u3002</div>';
+  errorContainer.appendChild(div);
+  container.appendChild(errorContainer);
+}
+async function sanitizeDescription(description) {
+  const { default: sanitizeHtml } = await import("sanitize-html");
+  return sanitizeHtml(description, {
+    allowedTags: sanitizeHtml.defaults.allowedTags.concat(["img"]),
+    allowedAttributes: {
+      ...sanitizeHtml.defaults.allowedAttributes,
+      "*": ["class"]
+    }
+  });
+}
+function loadImageCompatibility(promise, callback) {
+  promise.then((response) => {
+    callback(null, response.data, {
+      cacheControl: response.cacheControl,
+      expires: response.expires
+    });
+  }).catch((error) => {
+    callback(error);
+  });
+}
+
+// src/lib/simplestyle.ts
+var textColor = "#000000";
+var textHaloColor = "#FFFFFF";
+var backgroundColor = "rgba(255, 0, 0, 0.4)";
+var strokeColor = "#FFFFFF";
+var template = {
+  type: "FeatureCollection",
+  features: []
+};
+var SimpleStyle = class {
+  constructor(geojson, options) {
+    this.callFitBounds = false;
+    this._eventHandlers = [];
+    this.setGeoJSON(geojson);
+    this.options = {
+      id: "geolonia-simple-style",
+      cluster: true,
+      heatmap: false,
+      // TODO: It should support heatmap.
+      clusterColor: "#ff0000",
+      ...options
+    };
+  }
+  updateData(geojson) {
+    this.setGeoJSON(geojson);
+    const features = this.geojson.features;
+    const polygonAndLines = features.filter(
+      (feature) => feature.geometry.type.toLowerCase() !== "point"
+    );
+    const points = features.filter(
+      (feature) => feature.geometry.type.toLowerCase() === "point"
+    );
+    this.map.getSource(this.options.id).setData({
+      type: "FeatureCollection",
+      features: polygonAndLines
+    });
+    this.map.getSource(`${this.options.id}-points`).setData({
+      type: "FeatureCollection",
+      features: points
+    });
+    return this;
+  }
+  addTo(map) {
+    this.map = map;
+    const features = this.geojson.features;
+    const polygonAndLines = features.filter(
+      (feature) => feature.geometry.type.toLowerCase() !== "point"
+    );
+    const points = features.filter(
+      (feature) => feature.geometry.type.toLowerCase() === "point"
+    );
+    this.map.addSource(this.options.id, {
+      type: "geojson",
+      data: {
+        type: "FeatureCollection",
+        features: polygonAndLines
+      }
+    });
+    this.setPolygonGeometries();
+    this.setLineGeometries();
+    this.map.addSource(`${this.options.id}-points`, {
+      type: "geojson",
+      data: {
+        type: "FeatureCollection",
+        features: points
+      },
+      cluster: this.options.cluster,
+      clusterMaxZoom: 14,
+      clusterRadius: 50
+    });
+    this.map.addLayer({
+      id: `${this.options.id}-polygon-symbol`,
+      type: "symbol",
+      source: this.options.id,
+      filter: ["==", "$type", "Polygon"],
+      paint: {
+        "text-color": ["string", ["get", "text-color"], textColor],
+        "text-halo-color": [
+          "string",
+          ["get", "text-halo-color"],
+          textHaloColor
+        ],
+        "text-halo-width": 1
+      },
+      layout: {
+        "text-field": ["get", "title"],
+        "text-font": ["Noto Sans Regular"],
+        "text-size": 12,
+        "text-max-width": 12,
+        "text-allow-overlap": false
+      }
+    });
+    this.map.addLayer({
+      id: `${this.options.id}-linestring-symbol`,
+      type: "symbol",
+      source: this.options.id,
+      filter: ["==", "$type", "LineString"],
+      paint: {
+        "text-color": ["string", ["get", "text-color"], textColor],
+        "text-halo-color": [
+          "string",
+          ["get", "text-halo-color"],
+          textHaloColor
+        ],
+        "text-halo-width": 1
+      },
+      layout: {
+        "symbol-placement": "line",
+        "text-field": ["get", "title"],
+        "text-font": ["Noto Sans Regular"],
+        "text-size": 12,
+        "text-max-width": 12,
+        "text-allow-overlap": false
+      }
+    });
+    this.setPointGeometries();
+    this.setCluster();
+    return this;
+  }
+  fitBounds(options = {}) {
+    this.callFitBounds = true;
+    const _options = {
+      duration: 3e3,
+      padding: 30,
+      ...options
+    };
+    const bounds = (0, import_geojson_extent.default)(this.geojson);
+    if (bounds) {
+      window.requestAnimationFrame(() => {
+        this.map.fitBounds(bounds, _options);
+      });
+    }
+    return this;
+  }
+  /**
+   * Set polygon geometries.
+   */
+  setPolygonGeometries() {
+    this.map.addLayer({
+      id: `${this.options.id}-polygon`,
+      type: "fill",
+      source: this.options.id,
+      filter: ["==", "$type", "Polygon"],
+      paint: {
+        "fill-color": ["string", ["get", "fill"], backgroundColor],
+        "fill-opacity": ["number", ["get", "fill-opacity"], 1],
+        "fill-outline-color": ["string", ["get", "stroke"], strokeColor]
+      }
+    });
+    this.setPopup(this.map, `${this.options.id}-polygon`);
+  }
+  /**
+   * Set line geometries.
+   */
+  setLineGeometries() {
+    this.map.addLayer({
+      id: `${this.options.id}-linestring`,
+      type: "line",
+      source: this.options.id,
+      filter: ["==", "$type", "LineString"],
+      paint: {
+        "line-width": ["number", ["get", "stroke-width"], 2],
+        "line-color": ["string", ["get", "stroke"], backgroundColor],
+        "line-opacity": ["number", ["get", "stroke-opacity"], 1]
+      },
+      layout: {
+        "line-cap": "round",
+        "line-join": "round"
+      }
+    });
+    this.setPopup(this.map, `${this.options.id}-linestring`);
+  }
+  /**
+   * Setup point geometries.
+   */
+  setPointGeometries() {
+    this.map.addLayer({
+      id: `${this.options.id}-circle-points`,
+      type: "circle",
+      source: `${this.options.id}-points`,
+      filter: ["all", ["!has", "point_count"], ["!has", "marker-symbol"]],
+      paint: {
+        "circle-radius": [
+          "case",
+          ["==", "small", ["get", "marker-size"]],
+          7,
+          ["==", "large", ["get", "marker-size"]],
+          13,
+          9
+        ],
+        "circle-color": ["string", ["get", "marker-color"], backgroundColor],
+        "circle-opacity": ["number", ["get", "fill-opacity"], 1],
+        "circle-stroke-width": ["number", ["get", "stroke-width"], 1],
+        "circle-stroke-color": ["string", ["get", "stroke"], strokeColor],
+        "circle-stroke-opacity": ["number", ["get", "stroke-opacity"], 1]
+      }
+    });
+    this.map.addLayer({
+      id: `${this.options.id}-symbol-points`,
+      type: "symbol",
+      source: `${this.options.id}-points`,
+      filter: ["!", ["has", "point_count"]],
+      paint: {
+        "text-color": ["string", ["get", "text-color"], textColor],
+        "text-halo-color": [
+          "string",
+          ["get", "text-halo-color"],
+          textHaloColor
+        ],
+        "text-halo-width": 1
+      },
+      layout: {
+        "icon-image": ["get", "marker-symbol"],
+        "text-field": ["get", "title"],
+        "text-font": ["Noto Sans Regular"],
+        "text-size": 12,
+        "text-max-width": 12,
+        "text-allow-overlap": true,
+        "icon-allow-overlap": true,
+        "text-variable-anchor": ["top", "bottom", "left", "right"],
+        "text-radial-offset": [
+          "case",
+          ["==", "small", ["get", "marker-size"]],
+          1,
+          ["==", "large", ["get", "marker-size"]],
+          1.6,
+          1.2
+        ]
+      }
+    });
+    this.setPopup(this.map, `${this.options.id}-circle-points`);
+    this.setPopup(this.map, `${this.options.id}-symbol-points`);
+  }
+  async setPopup(map, source) {
+    const clickHandler = async (e) => {
+      const center = (0, import_center.default)(e.features[0]).geometry.coordinates;
+      const description = e.features[0].properties.description;
+      if (description) {
+        const sanitizedDescription = await sanitizeDescription(description);
+        new import_maplibre_gl2.default.Popup().setLngLat(center).setHTML(sanitizedDescription).addTo(map);
+      }
+    };
+    const mouseEnterHandler = (e) => {
+      if (e.features[0].properties.description) {
+        map.getCanvas().style.cursor = "pointer";
+      }
+    };
+    const mouseLeaveHandler = () => {
+      map.getCanvas().style.cursor = "";
+    };
+    map.on("click", source, clickHandler);
+    map.on("mouseenter", source, mouseEnterHandler);
+    map.on("mouseleave", source, mouseLeaveHandler);
+    this._eventHandlers.push(
+      { event: "click", layer: source, handler: clickHandler },
+      { event: "mouseenter", layer: source, handler: mouseEnterHandler },
+      { event: "mouseleave", layer: source, handler: mouseLeaveHandler }
+    );
+  }
+  /**
+   * Setup cluster markers
+   */
+  setCluster() {
+    this.map.addLayer({
+      id: `${this.options.id}-clusters`,
+      type: "circle",
+      source: `${this.options.id}-points`,
+      filter: ["has", "point_count"],
+      paint: {
+        "circle-radius": 20,
+        "circle-color": this.options.clusterColor,
+        "circle-opacity": 1
+      }
+    });
+    this.map.addLayer({
+      id: `${this.options.id}-cluster-count`,
+      type: "symbol",
+      source: `${this.options.id}-points`,
+      filter: ["has", "point_count"],
+      layout: {
+        "text-field": "{point_count_abbreviated}",
+        "text-size": 14,
+        "text-font": ["Noto Sans Regular"]
+      }
+    });
+    const clusterLayer = `${this.options.id}-clusters`;
+    const clusterClickHandler = async (e) => {
+      const features = this.map.queryRenderedFeatures(e.point, {
+        layers: [clusterLayer]
+      });
+      const clusterId = features[0].properties.cluster_id;
+      const zoom = await this.map.getSource(`${this.options.id}-points`).getClusterExpansionZoom(clusterId);
+      this.map.easeTo({
+        center: features[0].geometry.coordinates,
+        zoom
+      });
+    };
+    const clusterEnterHandler = () => {
+      this.map.getCanvas().style.cursor = "pointer";
+    };
+    const clusterLeaveHandler = () => {
+      this.map.getCanvas().style.cursor = "";
+    };
+    this.map.on("click", clusterLayer, clusterClickHandler);
+    this.map.on("mouseenter", clusterLayer, clusterEnterHandler);
+    this.map.on("mouseleave", clusterLayer, clusterLeaveHandler);
+    this._eventHandlers.push(
+      { event: "click", layer: clusterLayer, handler: clusterClickHandler },
+      {
+        event: "mouseenter",
+        layer: clusterLayer,
+        handler: clusterEnterHandler
+      },
+      {
+        event: "mouseleave",
+        layer: clusterLayer,
+        handler: clusterLeaveHandler
+      }
+    );
+  }
+  remove() {
+    if (!this.map) return this;
+    const id = this.options.id;
+    for (const { event, layer, handler } of this._eventHandlers) {
+      this.map.off(event, layer, handler);
+    }
+    this._eventHandlers = [];
+    const layerIds = [
+      `${id}-polygon-symbol`,
+      `${id}-linestring-symbol`,
+      `${id}-circle-points`,
+      `${id}-symbol-points`,
+      `${id}-polygon`,
+      `${id}-linestring`,
+      `${id}-clusters`,
+      `${id}-cluster-count`
+    ];
+    for (const layerId of layerIds) {
+      if (this.map.getLayer(layerId)) {
+        this.map.removeLayer(layerId);
+      }
+    }
+    for (const sourceId of [id, `${id}-points`]) {
+      if (this.map.getSource(sourceId)) {
+        this.map.removeSource(sourceId);
+      }
+    }
+    this.map.getCanvas().style.cursor = "";
+    return this;
+  }
+  setGeoJSON(geojson) {
+    if (typeof geojson === "string" && isURL(geojson)) {
+      this.geojson = template;
+      const fetchGeoJSON = async () => {
+        try {
+          const response = await window.fetch(geojson);
+          const data = response.ok ? await response.json() : {};
+          this.geojson = data;
+          this.updateData(data);
+          if (this.callFitBounds) {
+            this.fitBounds();
+            this.callFitBounds = false;
+          }
+        } catch (error) {
+          console.error("[Geolonia] Failed to load GeoJSON:", error);
+        }
+      };
+      this._loadingPromise = fetchGeoJSON();
+    } else {
+      this.geojson = geojson;
+    }
+  }
+};
+
+// src/lib/simplestyle-vector.ts
+var import_center2 = __toESM(require("@turf/center"), 1);
+var import_maplibre_gl3 = __toESM(require("maplibre-gl"), 1);
+var textColor2 = "#000000";
+var textHaloColor2 = "#FFFFFF";
+var backgroundColor2 = "rgba(255, 0, 0, 0.4)";
+var strokeColor2 = "#FFFFFF";
+var SimpleStyleVector = class {
+  constructor(url) {
+    this.url = url;
+    this.sourceName = "vt-geolonia-simple-style";
+  }
+  /* eslint-disable @typescript-eslint/no-explicit-any */
+  addTo(map) {
+    const container = map.getContainer();
+    if (!container.dataset || !container.dataset.lng && !container.dataset.lat) {
+      let initialZoomDone = false;
+      map.on("sourcedata", (event) => {
+        if (event.sourceId !== this.sourceName) {
+          return;
+        }
+        const source = map.getSource(event.sourceId);
+        const isLoaded = source && source.loaded();
+        if (isLoaded !== true) {
+          return;
+        }
+        if (initialZoomDone) {
+          return;
+        }
+        initialZoomDone = true;
+        map.fitBounds(source.bounds, {
+          duration: 0,
+          padding: 30
+        });
+      });
+    }
+    map.addSource(this.sourceName, {
+      type: "vector",
+      url: this.url
+    });
+    this.setPolygonGeometries(map);
+    this.setLineGeometries(map);
+    map.addLayer({
+      id: "vt-geolonia-simple-style-polygon-symbol",
+      type: "symbol",
+      source: this.sourceName,
+      "source-layer": "g-simplestyle-v1",
+      filter: ["==", "$type", "Polygon"],
+      paint: {
+        "text-color": ["string", ["get", "text-color"], textColor2],
+        "text-halo-color": [
+          "string",
+          ["get", "text-halo-color"],
+          textHaloColor2
+        ],
+        "text-halo-width": 1
+      },
+      layout: {
+        "text-field": ["get", "title"],
+        "text-font": ["Noto Sans Regular"],
+        "text-size": 12,
+        "text-max-width": 12,
+        "text-allow-overlap": false
+      }
+    });
+    map.addLayer({
+      id: "vt-geolonia-simple-style-linestring-symbol",
+      type: "symbol",
+      source: this.sourceName,
+      "source-layer": "g-simplestyle-v1",
+      filter: ["==", "$type", "LineString"],
+      paint: {
+        "text-color": ["string", ["get", "text-color"], textColor2],
+        "text-halo-color": [
+          "string",
+          ["get", "text-halo-color"],
+          textHaloColor2
+        ],
+        "text-halo-width": 1
+      },
+      layout: {
+        "symbol-placement": "line",
+        "text-field": ["get", "title"],
+        "text-font": ["Noto Sans Regular"],
+        "text-size": 12,
+        "text-max-width": 12,
+        "text-allow-overlap": false
+      }
+    });
+    this.setPointGeometries(map);
+  }
+  /**
+   * Set polygon geometries.
+   *
+   * @param map
+   */
+  setPolygonGeometries(map) {
+    map.addLayer({
+      id: "vt-geolonia-simple-style-polygon",
+      type: "fill",
+      source: this.sourceName,
+      "source-layer": "g-simplestyle-v1",
+      filter: ["==", "$type", "Polygon"],
+      paint: {
+        "fill-color": ["string", ["get", "fill"], backgroundColor2],
+        "fill-opacity": ["number", ["get", "fill-opacity"], 1],
+        "fill-outline-color": ["string", ["get", "stroke"], strokeColor2]
+      }
+    });
+    this.setPopup(map, "vt-geolonia-simple-style-polygon");
+  }
+  /**
+   * Set line geometries.
+   *
+   * @param map
+   */
+  setLineGeometries(map) {
+    map.addLayer({
+      id: "vt-geolonia-simple-style-linestring",
+      type: "line",
+      source: this.sourceName,
+      "source-layer": "g-simplestyle-v1",
+      filter: ["==", "$type", "LineString"],
+      paint: {
+        "line-width": ["number", ["get", "stroke-width"], 2],
+        "line-color": ["string", ["get", "stroke"], backgroundColor2],
+        "line-opacity": ["number", ["get", "stroke-opacity"], 1]
+      },
+      layout: {
+        "line-cap": "round",
+        "line-join": "round"
+      }
+    });
+    this.setPopup(map, "vt-geolonia-simple-style-linestring");
+  }
+  /**
+   * Setup point geometries.
+   *
+   * @param map
+   */
+  setPointGeometries(map) {
+    map.addLayer({
+      id: "vt-circle-simple-style-points",
+      type: "circle",
+      source: this.sourceName,
+      "source-layer": "g-simplestyle-v1",
+      filter: ["all", ["==", "$type", "Point"], ["!has", "marker-symbol"]],
+      paint: {
+        "circle-radius": [
+          "case",
+          ["==", "small", ["get", "marker-size"]],
+          7,
+          ["==", "large", ["get", "marker-size"]],
+          13,
+          9
+        ],
+        "circle-color": ["string", ["get", "marker-color"], backgroundColor2],
+        "circle-opacity": ["number", ["get", "fill-opacity"], 1],
+        "circle-stroke-width": ["number", ["get", "stroke-width"], 1],
+        "circle-stroke-color": ["string", ["get", "stroke"], strokeColor2],
+        "circle-stroke-opacity": ["number", ["get", "stroke-opacity"], 1]
+      }
+    });
+    map.addLayer({
+      id: "vt-geolonia-simple-style-points",
+      type: "symbol",
+      source: this.sourceName,
+      "source-layer": "g-simplestyle-v1",
+      filter: ["==", "$type", "Point"],
+      paint: {
+        "text-color": ["string", ["get", "text-color"], textColor2],
+        "text-halo-color": [
+          "string",
+          ["get", "text-halo-color"],
+          textHaloColor2
+        ],
+        "text-halo-width": 1
+      },
+      layout: {
+        "icon-image": ["get", "marker-symbol"],
+        "text-field": ["get", "title"],
+        "text-font": ["Noto Sans Regular"],
+        "text-size": 12,
+        "text-anchor": "top",
+        "text-max-width": 12,
+        "text-offset": [
+          "case",
+          ["==", "small", ["get", "marker-size"]],
+          ["literal", [0, 1]],
+          ["==", "large", ["get", "marker-size"]],
+          ["literal", [0, 1.6]],
+          ["literal", [0, 1.2]]
+        ],
+        "text-allow-overlap": false
+      }
+    });
+    this.setPopup(map, "vt-circle-simple-style-points");
+    this.setPopup(map, "vt-geolonia-simple-style-points");
+  }
+  async setPopup(map, source) {
+    map.on("click", source, async (e) => {
+      const center = (0, import_center2.default)(e.features[0]).geometry.coordinates;
+      const description = e.features[0].properties.description;
+      if (description) {
+        const sanitizedDescription = await sanitizeDescription(description);
+        new import_maplibre_gl3.default.Popup().setLngLat(center).setHTML(sanitizedDescription).addTo(map);
+      }
+    });
+    map.on("mouseenter", source, (e) => {
+      if (e.features[0].properties.description) {
+        map.getCanvas().style.cursor = "pointer";
+      }
+    });
+    map.on("mouseleave", source, () => {
+      map.getCanvas().style.cursor = "";
+    });
+  }
+};
+var simplestyle_vector_default = SimpleStyleVector;
+
+// src/lib/geolonia-map.ts
+var pmtilesRegistered = false;
+function ensurePMTiles() {
+  if (pmtilesRegistered) return;
+  pmtilesRegistered = true;
+  const protocol = new import_pmtiles.Protocol();
+  import_maplibre_gl4.default.addProtocol("pmtiles", protocol.tile);
+}
+var GeoloniaMap = class extends import_maplibre_gl4.default.Map {
+  constructor(options) {
+    ensurePMTiles();
+    if (options.apiKey) {
+      keyring.setApiKey(options.apiKey);
+    }
+    if (options.stage) {
+      keyring.setStage(options.stage);
+    }
+    const lang = options.lang === "auto" || !options.lang ? getLang() : options.lang;
+    const styleName = options.style || "geolonia/basic-v2";
+    keyring.isGeoloniaStyle = keyring.isGeoloniaStyleCheck(styleName);
+    const resolvedStyle = getStyle(styleName, {
+      lang,
+      apiKey: options.apiKey || keyring.apiKey
+    });
+    const container = typeof options.container === "string" ? document.querySelector(options.container) || document.getElementById(options.container) : options.container;
+    if (!container) {
+      throw new Error(
+        `[Geolonia] No HTML elements found. Please ensure the map container element exists.`
+      );
+    }
+    if (container.geoloniaMap) {
+      return container.geoloniaMap;
+    }
+    const apiKey = options.apiKey || keyring.apiKey;
+    const stage = options.stage || keyring.stage;
+    const apiUrl = `https://api.geolonia.com/${stage}`;
+    const sessionId2 = getSessionId(40);
+    const sourcesUrl = new URL(`${apiUrl}/sources`);
+    sourcesUrl.searchParams.set("key", apiKey);
+    sourcesUrl.searchParams.set("sessionId", sessionId2);
+    const userTransformRequest = options.transformRequest;
+    const transformRequest = (url, resourceType) => {
+      if (resourceType === "Source" && url.startsWith("https://api.geolonia.com")) {
+        return { url: sourcesUrl.toString() };
+      }
+      let transformedUrl = url;
+      if (url.startsWith("geolonia://")) {
+        const tilesMatch = url.match(
+          /^geolonia:\/\/tiles\/(?<username>.+)\/(?<customtileId>.+)/
+        );
+        if (tilesMatch?.groups) {
+          transformedUrl = `https://tileserver.geolonia.com/customtiles/${tilesMatch.groups.customtileId}/tiles.json`;
+        }
+      }
+      const transformedUrlObj = new URL(transformedUrl);
+      const geoloniaTilesHost = isGeoloniaTilesHost(transformedUrlObj);
+      if (resourceType === "Source" && geoloniaTilesHost) {
+        if (stage === "dev" && transformedUrlObj.hostname === "tileserver.geolonia.com") {
+          transformedUrlObj.hostname = "tileserver-dev.geolonia.com";
+        }
+        transformedUrlObj.searchParams.set("sessionId", sessionId2);
+        transformedUrlObj.searchParams.set("key", apiKey);
+        return { url: transformedUrlObj.toString() };
+      }
+      if ((resourceType === "SpriteJSON" || resourceType === "SpriteImage") && transformedUrl.match(
+        /^https:\/\/api\.geolonia\.com\/(dev|v1)\/sprites\//
+      )) {
+        const pathParts = transformedUrlObj.pathname.split("/");
+        pathParts[1] = stage;
+        transformedUrlObj.pathname = pathParts.join("/");
+        transformedUrlObj.searchParams.set("key", apiKey);
+        return { url: transformedUrlObj.toString() };
+      }
+      if (typeof userTransformRequest === "function") {
+        return userTransformRequest(transformedUrl, resourceType);
+      }
+      return void 0;
+    };
+    let loading;
+    const showLoader = options.loader !== false;
+    if (showLoader) {
+      loading = document.createElement("div");
+      loading.className = "loading-geolonia-map";
+      loading.innerHTML = `<div class="lds-grid"><div></div><div></div><div></div>
+          <div></div><div></div><div></div><div></div><div></div><div></div></div>`;
+      container.appendChild(loading);
+    }
+    const mapOptions = {
+      ...options,
+      container,
+      style: resolvedStyle,
+      hash: options.hash ?? false,
+      localIdeographFontFamily: options.localIdeographFontFamily ?? "sans-serif",
+      attributionControl: false,
+      transformRequest
+    };
+    for (const key of [
+      "apiKey",
+      "stage",
+      "lang",
+      "marker",
+      "markerColor",
+      "openPopup",
+      "customMarker",
+      "customMarkerOffset",
+      "loader",
+      "gestureHandling",
+      "navigationControl",
+      "geolocateControl",
+      "fullscreenControl",
+      "scaleControl",
+      "geoloniaControl",
+      "geojson",
+      "cluster",
+      "clusterColor",
+      "simpleVector",
+      "3d"
+    ]) {
+      delete mapOptions[key];
+    }
+    try {
+      super(mapOptions);
+    } catch (error) {
+      handleErrorMode(container);
+      throw error;
+    }
+    this.geoloniaSourcesUrl = sourcesUrl;
+    this.__styleExtensionLoadRequired = true;
+    const geoloniaCtrl = parseControlOption(options.geoloniaControl ?? true);
+    this.addControl(
+      new GeoloniaControl(),
+      geoloniaCtrl.position
+    );
+    this.addControl(new attribution_default(), "bottom-right");
+    const fullscreen = parseControlOption(options.fullscreenControl ?? false);
+    if (fullscreen.enabled) {
+      this.addControl(
+        new import_maplibre_gl4.FullscreenControl(),
+        fullscreen.position
+      );
+    }
+    const nav = parseControlOption(options.navigationControl ?? true);
+    if (nav.enabled) {
+      this.addControl(new import_maplibre_gl4.NavigationControl(), nav.position);
+    }
+    const geolocate = parseControlOption(options.geolocateControl ?? false);
+    if (geolocate.enabled) {
+      this.addControl(
+        new import_maplibre_gl4.GeolocateControl({}),
+        geolocate.position
+      );
+    }
+    const scale = parseControlOption(options.scaleControl ?? false);
+    if (scale.enabled) {
+      this.addControl(new import_maplibre_gl4.ScaleControl({}), scale.position);
+    }
+    this.on("load", (event) => {
+      const map = event.target;
+      if (loading) {
+        try {
+          container.removeChild(loading);
+        } catch {
+        }
+      }
+      if (options.gestureHandling !== false) {
+        import("@geolonia/mbgl-gesture-handling").then(({ default: GestureHandling }) => {
+          const body = document.body;
+          const html = document.documentElement;
+          const isScrollable = body.scrollHeight > body.clientHeight || html.scrollHeight > html.clientHeight;
+          if (isScrollable) {
+            new GestureHandling({ lang }).addTo(map);
+          }
+        }).catch(() => {
+        });
+      }
+      if (options.marker && options.center) {
+        const c = options.center;
+        const center = Array.isArray(c) ? [c[0], c[1]] : "lng" in c ? [c.lng, c.lat] : [c.lon, c.lat];
+        let marker;
+        if (options.customMarker) {
+          const customEl = document.querySelector(
+            options.customMarker
+          );
+          if (customEl) {
+            customEl.style.display = "block";
+            marker = new GeoloniaMarker({
+              element: customEl,
+              offset: options.customMarkerOffset || [0, 0]
+            }).setLngLat(center).addTo(map);
+          } else {
+            marker = new GeoloniaMarker({ color: options.markerColor }).setLngLat(center).addTo(map);
+          }
+        } else {
+          marker = new GeoloniaMarker({ color: options.markerColor }).setLngLat(center).addTo(map);
+        }
+        const content = container.dataset?.popupContent;
+        if (content) {
+          const popup = new import_maplibre_gl4.Popup({ offset: [0, -25] }).setHTML(content);
+          marker.setPopup(popup);
+          if (options.openPopup) {
+            marker.togglePopup();
+          }
+        } else if (options.openPopup) {
+        }
+        marker.getElement().classList.add("geolonia-clickable-marker");
+      }
+    });
+    this.on("styledata", async () => {
+      if (!this.__styleExtensionLoadRequired) {
+        return;
+      }
+      this.__styleExtensionLoadRequired = false;
+      if (options.simpleVector) {
+        const url = parseSimpleVector(options.simpleVector);
+        new simplestyle_vector_default(url).addTo(this);
+      }
+      if (options.geojson) {
+        const ss = new SimpleStyle(options.geojson, {
+          cluster: options.cluster !== false,
+          clusterColor: options.clusterColor || "#ff0000"
+        });
+        ss.addTo(this);
+        if (!options.center) {
+          ss.fitBounds();
+        }
+      }
+      if (options["3d"] === true) {
+        const style = this.getStyle();
+        if (style?.layers) {
+          for (const layer of style.layers) {
+            const metadata = layer.metadata;
+            if (metadata?.["visible-on-3d"]) {
+              this.setLayoutProperty(layer.id, "visibility", "visible");
+            }
+            if (metadata?.["hide-on-3d"]) {
+              this.setLayoutProperty(layer.id, "visibility", "none");
+            }
+          }
+        }
+      }
+    });
+    this.on("error", async (error) => {
+      if (error.error && error.error.status === 402) {
+        handleRestrictedMode(this);
+      }
+    });
+    container.geoloniaMap = this;
+    return this;
+  }
+  setStyle(style, options = {}) {
+    if (style !== null && typeof style === "string") {
+      style = getStyle(style, { lang: getLang(), apiKey: keyring.apiKey });
+    }
+    this.__styleExtensionLoadRequired = true;
+    super.setStyle.call(this, style, options);
+    return this;
+  }
+  remove() {
+    const container = this.getContainer();
+    super.remove.call(this);
+    delete container.geoloniaMap;
+  }
+  loadImage(url, callback) {
+    const promise = super.loadImage(url);
+    if (callback) {
+      loadImageCompatibility(promise, callback);
+    } else {
+      return promise;
+    }
+  }
+};
+
+// src/version.ts
+var VERSION = "0.1.0";
+// Annotate the CommonJS export names for ESM import in node:
+0 && (module.exports = {
+  CustomAttributionControl,
+  GeoloniaControl,
+  GeoloniaMap,
+  GeoloniaMarker,
+  SimpleStyle,
+  SimpleStyleVector,
+  coreVersion,
+  getLang,
+  getStyle,
+  isGeoloniaTilesHost,
+  keyring
+});

--- a/public/maps-core/index.js
+++ b/public/maps-core/index.js
@@ -1,0 +1,1841 @@
+var __typeError = (msg) => {
+  throw TypeError(msg);
+};
+var __accessCheck = (obj, member, msg) => member.has(obj) || __typeError("Cannot " + msg);
+var __privateGet = (obj, member, getter) => (__accessCheck(obj, member, "read from private field"), getter ? getter.call(obj) : member.get(obj));
+var __privateAdd = (obj, member, value) => member.has(obj) ? __typeError("Cannot add the same private member more than once") : member instanceof WeakSet ? member.add(obj) : member.set(obj, value);
+var __privateSet = (obj, member, value, setter) => (__accessCheck(obj, member, "write to private field"), setter ? setter.call(obj, value) : member.set(obj, value), value);
+
+// node_modules/@mapbox/point-geometry/index.js
+function Point(x, y) {
+  this.x = x;
+  this.y = y;
+}
+Point.prototype = {
+  /**
+   * Clone this point, returning a new point that can be modified
+   * without affecting the old one.
+   * @return {Point} the clone
+   */
+  clone() {
+    return new Point(this.x, this.y);
+  },
+  /**
+   * Add this point's x & y coordinates to another point,
+   * yielding a new point.
+   * @param {Point} p the other point
+   * @return {Point} output point
+   */
+  add(p) {
+    return this.clone()._add(p);
+  },
+  /**
+   * Subtract this point's x & y coordinates to from point,
+   * yielding a new point.
+   * @param {Point} p the other point
+   * @return {Point} output point
+   */
+  sub(p) {
+    return this.clone()._sub(p);
+  },
+  /**
+   * Multiply this point's x & y coordinates by point,
+   * yielding a new point.
+   * @param {Point} p the other point
+   * @return {Point} output point
+   */
+  multByPoint(p) {
+    return this.clone()._multByPoint(p);
+  },
+  /**
+   * Divide this point's x & y coordinates by point,
+   * yielding a new point.
+   * @param {Point} p the other point
+   * @return {Point} output point
+   */
+  divByPoint(p) {
+    return this.clone()._divByPoint(p);
+  },
+  /**
+   * Multiply this point's x & y coordinates by a factor,
+   * yielding a new point.
+   * @param {number} k factor
+   * @return {Point} output point
+   */
+  mult(k) {
+    return this.clone()._mult(k);
+  },
+  /**
+   * Divide this point's x & y coordinates by a factor,
+   * yielding a new point.
+   * @param {number} k factor
+   * @return {Point} output point
+   */
+  div(k) {
+    return this.clone()._div(k);
+  },
+  /**
+   * Rotate this point around the 0, 0 origin by an angle a,
+   * given in radians
+   * @param {number} a angle to rotate around, in radians
+   * @return {Point} output point
+   */
+  rotate(a) {
+    return this.clone()._rotate(a);
+  },
+  /**
+   * Rotate this point around p point by an angle a,
+   * given in radians
+   * @param {number} a angle to rotate around, in radians
+   * @param {Point} p Point to rotate around
+   * @return {Point} output point
+   */
+  rotateAround(a, p) {
+    return this.clone()._rotateAround(a, p);
+  },
+  /**
+   * Multiply this point by a 4x1 transformation matrix
+   * @param {[number, number, number, number]} m transformation matrix
+   * @return {Point} output point
+   */
+  matMult(m) {
+    return this.clone()._matMult(m);
+  },
+  /**
+   * Calculate this point but as a unit vector from 0, 0, meaning
+   * that the distance from the resulting point to the 0, 0
+   * coordinate will be equal to 1 and the angle from the resulting
+   * point to the 0, 0 coordinate will be the same as before.
+   * @return {Point} unit vector point
+   */
+  unit() {
+    return this.clone()._unit();
+  },
+  /**
+   * Compute a perpendicular point, where the new y coordinate
+   * is the old x coordinate and the new x coordinate is the old y
+   * coordinate multiplied by -1
+   * @return {Point} perpendicular point
+   */
+  perp() {
+    return this.clone()._perp();
+  },
+  /**
+   * Return a version of this point with the x & y coordinates
+   * rounded to integers.
+   * @return {Point} rounded point
+   */
+  round() {
+    return this.clone()._round();
+  },
+  /**
+   * Return the magnitude of this point: this is the Euclidean
+   * distance from the 0, 0 coordinate to this point's x and y
+   * coordinates.
+   * @return {number} magnitude
+   */
+  mag() {
+    return Math.sqrt(this.x * this.x + this.y * this.y);
+  },
+  /**
+   * Judge whether this point is equal to another point, returning
+   * true or false.
+   * @param {Point} other the other point
+   * @return {boolean} whether the points are equal
+   */
+  equals(other) {
+    return this.x === other.x && this.y === other.y;
+  },
+  /**
+   * Calculate the distance from this point to another point
+   * @param {Point} p the other point
+   * @return {number} distance
+   */
+  dist(p) {
+    return Math.sqrt(this.distSqr(p));
+  },
+  /**
+   * Calculate the distance from this point to another point,
+   * without the square root step. Useful if you're comparing
+   * relative distances.
+   * @param {Point} p the other point
+   * @return {number} distance
+   */
+  distSqr(p) {
+    const dx = p.x - this.x, dy = p.y - this.y;
+    return dx * dx + dy * dy;
+  },
+  /**
+   * Get the angle from the 0, 0 coordinate to this point, in radians
+   * coordinates.
+   * @return {number} angle
+   */
+  angle() {
+    return Math.atan2(this.y, this.x);
+  },
+  /**
+   * Get the angle from this point to another point, in radians
+   * @param {Point} b the other point
+   * @return {number} angle
+   */
+  angleTo(b) {
+    return Math.atan2(this.y - b.y, this.x - b.x);
+  },
+  /**
+   * Get the angle between this point and another point, in radians
+   * @param {Point} b the other point
+   * @return {number} angle
+   */
+  angleWith(b) {
+    return this.angleWithSep(b.x, b.y);
+  },
+  /**
+   * Find the angle of the two vectors, solving the formula for
+   * the cross product a x b = |a||b|sin(θ) for θ.
+   * @param {number} x the x-coordinate
+   * @param {number} y the y-coordinate
+   * @return {number} the angle in radians
+   */
+  angleWithSep(x, y) {
+    return Math.atan2(
+      this.x * y - this.y * x,
+      this.x * x + this.y * y
+    );
+  },
+  /** @param {[number, number, number, number]} m */
+  _matMult(m) {
+    const x = m[0] * this.x + m[1] * this.y, y = m[2] * this.x + m[3] * this.y;
+    this.x = x;
+    this.y = y;
+    return this;
+  },
+  /** @param {Point} p */
+  _add(p) {
+    this.x += p.x;
+    this.y += p.y;
+    return this;
+  },
+  /** @param {Point} p */
+  _sub(p) {
+    this.x -= p.x;
+    this.y -= p.y;
+    return this;
+  },
+  /** @param {number} k */
+  _mult(k) {
+    this.x *= k;
+    this.y *= k;
+    return this;
+  },
+  /** @param {number} k */
+  _div(k) {
+    this.x /= k;
+    this.y /= k;
+    return this;
+  },
+  /** @param {Point} p */
+  _multByPoint(p) {
+    this.x *= p.x;
+    this.y *= p.y;
+    return this;
+  },
+  /** @param {Point} p */
+  _divByPoint(p) {
+    this.x /= p.x;
+    this.y /= p.y;
+    return this;
+  },
+  _unit() {
+    this._div(this.mag());
+    return this;
+  },
+  _perp() {
+    const y = this.y;
+    this.y = this.x;
+    this.x = -y;
+    return this;
+  },
+  /** @param {number} angle */
+  _rotate(angle) {
+    const cos = Math.cos(angle), sin = Math.sin(angle), x = cos * this.x - sin * this.y, y = sin * this.x + cos * this.y;
+    this.x = x;
+    this.y = y;
+    return this;
+  },
+  /**
+   * @param {number} angle
+   * @param {Point} p
+   */
+  _rotateAround(angle, p) {
+    const cos = Math.cos(angle), sin = Math.sin(angle), x = p.x + cos * (this.x - p.x) - sin * (this.y - p.y), y = p.y + sin * (this.x - p.x) + cos * (this.y - p.y);
+    this.x = x;
+    this.y = y;
+    return this;
+  },
+  _round() {
+    this.x = Math.round(this.x);
+    this.y = Math.round(this.y);
+    return this;
+  },
+  constructor: Point
+};
+Point.convert = function(p) {
+  if (p instanceof Point) {
+    return (
+      /** @type {Point} */
+      p
+    );
+  }
+  if (Array.isArray(p)) {
+    return new Point(+p[0], +p[1]);
+  }
+  if (p.x !== void 0 && p.y !== void 0) {
+    return new Point(+p.x, +p.y);
+  }
+  throw new Error("Expected [x, y] or {x, y} point format");
+};
+
+// src/lib/maplibre-util.ts
+var _docStyle, _userSelect, _selectProp, _transformProp;
+var _DOM = class _DOM {
+  static testProp(props) {
+    if (!__privateGet(_DOM, _docStyle)) return props[0];
+    for (let i = 0; i < props.length; i++) {
+      if (props[i] in __privateGet(_DOM, _docStyle)) {
+        return props[i];
+      }
+    }
+    return props[0];
+  }
+  static create(tagName, className, container) {
+    const el = window.document.createElement(tagName);
+    if (className !== void 0) el.className = className;
+    if (container) container.appendChild(el);
+    return el;
+  }
+  static createNS(namespaceURI, tagName) {
+    return window.document.createElementNS(namespaceURI, tagName);
+  }
+  static disableDrag() {
+    if (__privateGet(_DOM, _docStyle) && __privateGet(_DOM, _selectProp)) {
+      __privateSet(_DOM, _userSelect, __privateGet(_DOM, _docStyle)[__privateGet(_DOM, _selectProp)]);
+      __privateGet(_DOM, _docStyle)[__privateGet(_DOM, _selectProp)] = "none";
+    }
+  }
+  static enableDrag() {
+    if (__privateGet(_DOM, _docStyle) && __privateGet(_DOM, _selectProp)) {
+      __privateGet(_DOM, _docStyle)[__privateGet(_DOM, _selectProp)] = __privateGet(_DOM, _userSelect) ?? "";
+    }
+  }
+  static setTransform(el, value) {
+    el.style[__privateGet(_DOM, _transformProp)] = value;
+  }
+  static addEventListener(target, type, callback, options) {
+    if ("passive" in options) {
+      target.addEventListener(type, callback, options);
+    } else {
+      target.addEventListener(type, callback, options.capture);
+    }
+  }
+  static removeEventListener(target, type, callback, options) {
+    if ("passive" in options) {
+      target.removeEventListener(type, callback, options);
+    } else {
+      target.removeEventListener(type, callback, options.capture);
+    }
+  }
+  static mousePos(el, e) {
+    const rect = el.getBoundingClientRect();
+    return new Point(
+      e.clientX - rect.left - el.clientLeft,
+      e.clientY - rect.top - el.clientTop
+    );
+  }
+  static touchPos(el, touches) {
+    const rect = el.getBoundingClientRect();
+    const points = [];
+    for (let i = 0; i < touches.length; i++) {
+      points.push(
+        new Point(
+          touches[i].clientX - rect.left - el.clientLeft,
+          touches[i].clientY - rect.top - el.clientTop
+        )
+      );
+    }
+    return points;
+  }
+  static mouseButton(e) {
+    return e.button;
+  }
+  static remove(node) {
+    if (node.parentNode) {
+      node.parentNode.removeChild(node);
+    }
+  }
+};
+_docStyle = new WeakMap();
+_userSelect = new WeakMap();
+_selectProp = new WeakMap();
+_transformProp = new WeakMap();
+__privateAdd(_DOM, _docStyle, typeof window !== "undefined" && window.document && window.document.documentElement.style);
+__privateAdd(_DOM, _userSelect);
+__privateAdd(_DOM, _selectProp, _DOM.testProp([
+  "userSelect",
+  "MozUserSelect",
+  "WebkitUserSelect",
+  "msUserSelect"
+]));
+__privateAdd(_DOM, _transformProp, _DOM.testProp([
+  "transform",
+  "WebkitTransform"
+]));
+var DOM = _DOM;
+function bindAll(fns, context) {
+  for (const fn of fns) {
+    if (typeof context[fn] === "function") {
+      context[fn] = context[fn].bind(
+        context
+      );
+    }
+  }
+}
+
+// src/lib/controls/attribution.ts
+var ATTRIBUTION_CSS = `
+.maplibregl-ctrl {
+  font: 12px/20px Helvetica Neue,Arial,Helvetica,sans-serif;
+  clear: both;
+  pointer-events: auto;
+  transform: translate(0);
+}
+.maplibregl-ctrl-attrib-button:focus,.maplibregl-ctrl-group button:focus {
+  box-shadow: 0 0 2px 2px #0096ff
+}
+.maplibregl-ctrl.maplibregl-ctrl-attrib {
+  background-color: hsla(0,0%,100%,.5);
+  margin: 0;
+  padding: 0 5px
+}
+@media screen {
+  .maplibregl-ctrl-attrib.maplibregl-compact {
+    background-color: #fff;
+    border-radius: 12px;
+    box-sizing: content-box;
+    min-height: 20px;
+    padding: 2px 24px 2px 0;
+    position: relative;
+    margin: 10px 10px 10px auto;
+    width: 0;
+  }
+  .maplibregl-ctrl-attrib.maplibregl-compact-show {
+    padding: 2px 28px 2px 8px;
+    visibility: visible;
+    width: auto;
+  }
+  .maplibregl-ctrl-bottom-left>.maplibregl-ctrl-attrib.maplibregl-compact-show,
+  .maplibregl-ctrl-top-left>.maplibregl-ctrl-attrib.maplibregl-compact-show {
+    border-radius: 12px;
+    padding: 2px 8px 2px 28px
+  }
+  .maplibregl-ctrl-attrib.maplibregl-compact .maplibregl-ctrl-attrib-inner {
+    display: none
+  }
+  .maplibregl-ctrl-attrib-button {
+    background-color: hsla(0,0%,100%,.5);
+    background-image: url("data:image/svg+xml;charset=utf-8,%3Csvg width='24' height='24' viewBox='0 0 20 20' xmlns='http://www.w3.org/2000/svg' fill-rule='evenodd'%3E%3Cpath d='M4 10a6 6 0 1 0 12 0 6 6 0 1 0-12 0m5-3a1 1 0 1 0 2 0 1 1 0 1 0-2 0m0 3a1 1 0 1 1 2 0v3a1 1 0 1 1-2 0'/%3E%3C/svg%3E");
+    border: 0;
+    border-radius: 12px;
+    box-sizing: border-box;
+    cursor: pointer;
+    display: none;
+    height: 24px;
+    outline: none;
+    position: absolute;
+    right: 0;
+    top: 0;
+    width: 24px
+  }
+  .maplibregl-ctrl-attrib summary.maplibregl-ctrl-attrib-button {
+    appearance: none;
+    list-style: none
+  }
+  .maplibregl-ctrl-attrib summary.maplibregl-ctrl-attrib-button::-webkit-details-marker {
+    display: none
+  }
+  .maplibregl-ctrl-bottom-left .maplibregl-ctrl-attrib-button,
+  .maplibregl-ctrl-top-left .maplibregl-ctrl-attrib-button {
+    left: 0
+  }
+  .maplibregl-ctrl-attrib.maplibregl-compact .maplibregl-ctrl-attrib-button,
+  .maplibregl-ctrl-attrib.maplibregl-compact-show .maplibregl-ctrl-attrib-inner {
+    display: block
+  }
+  .maplibregl-ctrl-attrib.maplibregl-compact-show .maplibregl-ctrl-attrib-button {
+    background-color: rgb(0 0 0/5%)
+  }
+  .maplibregl-ctrl-bottom-right>.maplibregl-ctrl-attrib.maplibregl-compact:after {
+    bottom: 0; right: 0
+  }
+  .maplibregl-ctrl-top-right>.maplibregl-ctrl-attrib.maplibregl-compact:after {
+    right: 0; top: 0
+  }
+  .maplibregl-ctrl-top-left>.maplibregl-ctrl-attrib.maplibregl-compact:after {
+    left: 0; top: 0
+  }
+  .maplibregl-ctrl-bottom-left>.maplibregl-ctrl-attrib.maplibregl-compact:after {
+    bottom: 0; left: 0
+  }
+}
+@media screen and (-ms-high-contrast:active) {
+  .maplibregl-ctrl-attrib.maplibregl-compact:after {
+    background-image: url("data:image/svg+xml;charset=utf-8,%3Csvg width='24' height='24' viewBox='0 0 20 20' xmlns='http://www.w3.org/2000/svg' fill-rule='evenodd' fill='%23fff'%3E%3Cpath d='M4 10a6 6 0 1 0 12 0 6 6 0 1 0-12 0m5-3a1 1 0 1 0 2 0 1 1 0 1 0-2 0m0 3a1 1 0 1 1 2 0v3a1 1 0 1 1-2 0'/%3E%3C/svg%3E")
+  }
+}
+@media screen and (-ms-high-contrast:black-on-white) {
+  .maplibregl-ctrl-attrib.maplibregl-compact:after {
+    background-image: url("data:image/svg+xml;charset=utf-8,%3Csvg width='24' height='24' viewBox='0 0 20 20' xmlns='http://www.w3.org/2000/svg' fill-rule='evenodd'%3E%3Cpath d='M4 10a6 6 0 1 0 12 0 6 6 0 1 0-12 0m5-3a1 1 0 1 0 2 0 1 1 0 1 0-2 0m0 3a1 1 0 1 1 2 0v3a1 1 0 1 1-2 0'/%3E%3C/svg%3E")
+  }
+}
+@media print {
+  .maplibregl-ctrl-attrib-button {
+    display: none !important;
+  }
+}
+.maplibregl-ctrl-attrib a {
+  color: rgba(0,0,0,.75);
+  text-decoration: none;
+  white-space: nowrap;
+}
+.maplibregl-ctrl-attrib a:hover {
+  color: inherit;
+  text-decoration: underline
+}
+.maplibregl-attrib-empty {
+  display: none
+}
+`;
+var CustomAttributionControl = class {
+  constructor(options = {}) {
+    this._editLink = null;
+    this.options = options;
+    bindAll(
+      [
+        "_toggleAttribution",
+        "_updateData",
+        "_updateCompact",
+        "_updateCompactMinimize"
+      ],
+      this
+    );
+  }
+  getDefaultPosition() {
+    return "bottom-right";
+  }
+  onAdd(map) {
+    this._map = map;
+    this._compact = this.options.compact;
+    this._container = DOM.create("div");
+    const shadow = this._container.attachShadow({ mode: "open" });
+    this._shadowContainer = DOM.create(
+      "details",
+      "maplibregl-ctrl maplibregl-ctrl-attrib"
+    );
+    this._compactButton = DOM.create(
+      "summary",
+      "maplibregl-ctrl-attrib-button",
+      this._shadowContainer
+    );
+    this._compactButton.addEventListener("click", this._toggleAttribution);
+    this._setElementTitle(this._compactButton, "ToggleAttribution");
+    this._innerContainer = DOM.create(
+      "div",
+      "maplibregl-ctrl-attrib-inner",
+      this._shadowContainer
+    );
+    const style = document.createElement("style");
+    style.textContent = ATTRIBUTION_CSS;
+    this._updateAttributions();
+    this._updateCompact();
+    this._map.on("styledata", this._updateData);
+    this._map.on("sourcedata", this._updateData);
+    this._map.on("terrain", this._updateData);
+    this._map.on("resize", this._updateCompact);
+    this._map.on("drag", this._updateCompactMinimize);
+    shadow.appendChild(style);
+    shadow.appendChild(this._shadowContainer);
+    this.printQuery = window.matchMedia("print");
+    this.onMediaPrintChange = (e) => {
+      if (e.matches) {
+        this._shadowContainer.setAttribute("open", "");
+        this._shadowContainer.classList.remove("maplibregl-compact-show");
+      }
+    };
+    this.printQuery.addEventListener("change", this.onMediaPrintChange);
+    return this._container;
+  }
+  onRemove() {
+    if (this._container) {
+      DOM.remove(this._container);
+    }
+    if (this._map) {
+      this._map.off("styledata", this._updateData);
+      this._map.off("sourcedata", this._updateData);
+      this._map.off("terrain", this._updateData);
+      this._map.off("resize", this._updateCompact);
+      this._map.off("drag", this._updateCompactMinimize);
+    }
+    if (this.printQuery && this.onMediaPrintChange) {
+      this.printQuery.removeEventListener("change", this.onMediaPrintChange);
+    }
+    this._map = void 0;
+    this._compact = void 0;
+    this._attribHTML = void 0;
+  }
+  _setElementTitle(element, title) {
+    if (!this._map) return;
+    const str = this._map._getUIString(`AttributionControl.${title}`);
+    element.title = str;
+    element.setAttribute("aria-label", str);
+  }
+  _toggleAttribution() {
+    if (!this._shadowContainer) return;
+    if (this._shadowContainer.classList.contains("maplibregl-compact")) {
+      if (this._shadowContainer.classList.contains("maplibregl-compact-show")) {
+        this._shadowContainer.setAttribute("open", "");
+        this._shadowContainer.classList.remove("maplibregl-compact-show");
+      } else {
+        this._shadowContainer.classList.add("maplibregl-compact-show");
+        this._shadowContainer.removeAttribute("open");
+      }
+    }
+  }
+  _updateData(e) {
+    if (e && (e.sourceDataType === "metadata" || e.sourceDataType === "visibility" || e.dataType === "style" || e.type === "terrain")) {
+      this._updateAttributions();
+    }
+  }
+  _updateAttributions() {
+    if (!this._map || !this._map.style) return;
+    let attributions = [];
+    if (this.options.customAttribution) {
+      if (Array.isArray(this.options.customAttribution)) {
+        attributions = attributions.concat(
+          this.options.customAttribution.filter(
+            (attr) => typeof attr === "string"
+          )
+        );
+      } else if (typeof this.options.customAttribution === "string") {
+        attributions.push(this.options.customAttribution);
+      }
+    }
+    if (this._map.style.stylesheet) {
+      const stylesheet = this._map.style.stylesheet;
+      this.styleOwner = stylesheet.owner;
+      this.styleId = stylesheet.id;
+    }
+    const sourceCaches = this._map.style.sourceCaches;
+    for (const id in sourceCaches) {
+      const sourceCache = sourceCaches[id];
+      if (sourceCache.used || sourceCache.usedForTerrain) {
+        const source = sourceCache.getSource();
+        if (source.attribution && attributions.indexOf(source.attribution) < 0) {
+          attributions.push(source.attribution);
+        }
+      }
+    }
+    attributions = attributions.filter((e) => String(e).trim());
+    attributions.sort((a, b) => a.length - b.length);
+    attributions = attributions.filter((attrib, i) => {
+      for (let j = i + 1; j < attributions.length; j++) {
+        if (attributions[j].indexOf(attrib) >= 0) {
+          return false;
+        }
+      }
+      return true;
+    });
+    const attribHTML = attributions.join(" | ");
+    if (attribHTML === this._attribHTML) return;
+    this._attribHTML = attribHTML;
+    if (attributions.length) {
+      this._innerContainer.innerHTML = attribHTML;
+      this._shadowContainer.classList.remove("maplibregl-attrib-empty");
+    } else {
+      this._shadowContainer.classList.add("maplibregl-attrib-empty");
+    }
+    this._updateCompact();
+    this._editLink = null;
+  }
+  _updateCompact() {
+    if (!this._map || !this._shadowContainer) return;
+    if (this._map.getCanvasContainer().offsetWidth <= 640 || this._compact) {
+      if (this._compact === false) {
+        this._shadowContainer.setAttribute("open", "");
+      } else if (!this._shadowContainer.classList.contains("maplibregl-compact") && !this._shadowContainer.classList.contains("maplibregl-attrib-empty")) {
+        this._shadowContainer.setAttribute("open", "");
+        this._shadowContainer.classList.add(
+          "maplibregl-compact",
+          "maplibregl-compact-show"
+        );
+      }
+    } else {
+      this._shadowContainer.setAttribute("open", "");
+      if (this._shadowContainer.classList.contains("maplibregl-compact")) {
+        this._shadowContainer.classList.remove(
+          "maplibregl-compact",
+          "maplibregl-compact-show"
+        );
+      }
+    }
+  }
+  _updateCompactMinimize() {
+    if (!this._shadowContainer) return;
+    if (this._shadowContainer.classList.contains("maplibregl-compact")) {
+      if (this._shadowContainer.classList.contains("maplibregl-compact-show")) {
+        this._shadowContainer.classList.remove("maplibregl-compact-show");
+      }
+    }
+  }
+};
+var attribution_default = CustomAttributionControl;
+
+// src/lib/controls/geolonia-logo.ts
+var GeoloniaControl = class {
+  onAdd() {
+    this.container = document.createElement("div");
+    this.container.className = "maplibregl-ctrl";
+    const img = document.createElement("img");
+    img.src = "https://cdn.geolonia.com/logo/geolonia-symbol_1.png";
+    img.style.width = "16px";
+    img.style.height = "16px";
+    img.style.display = "block";
+    img.style.cursor = "pointer";
+    img.style.padding = "0";
+    img.style.margin = "0";
+    img.style.border = "none";
+    img.alt = "Geolonia";
+    const link = document.createElement("a");
+    link.href = "https://geolonia.com/";
+    link.appendChild(img);
+    link.title = "Powered by Geolonia";
+    this.container.appendChild(link);
+    return this.container;
+  }
+  onRemove() {
+    this.container.parentNode?.removeChild(this.container);
+  }
+  getDefaultPosition() {
+    return "bottom-left";
+  }
+};
+
+// src/lib/geolonia-map.ts
+import maplibregl4, {
+  FullscreenControl,
+  GeolocateControl,
+  NavigationControl,
+  Popup,
+  ScaleControl
+} from "maplibre-gl";
+import { Protocol } from "pmtiles";
+
+// src/lib/geolonia-marker.ts
+import maplibregl from "maplibre-gl";
+import tinycolor from "tinycolor2";
+var MARKER_SVG = `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 52 67">
+  <path class="left" d="M26 0C11.664 0 0 11.663 0 26c0 22.14 26 41 26 41V26h0C26 11.663 26 0 26 0z" fill="#E4402F"/>
+  <path class="right" d="M26 0c14.336 0 26 11.663 26 26 0 22.14-26 41-26 41V26h0C26 11.663 26 0 26 0z" fill="#C1272D"/>
+  <circle cx="26" cy="26" r="9" fill="#FFF"/>
+</svg>`;
+var DEFAULT_COLOR = "#E4402F";
+var GeoloniaMarker = class extends maplibregl.Marker {
+  constructor(options = {}) {
+    if (!options.element) {
+      const markerElement = document.createElement("div");
+      markerElement.className = "geolonia-default-marker";
+      markerElement.innerHTML = MARKER_SVG;
+      markerElement.style.margin = "0";
+      markerElement.style.padding = "0";
+      markerElement.style.width = "26px";
+      markerElement.style.height = "34px";
+      const svg = markerElement.querySelector("svg");
+      if (svg) {
+        svg.style.width = "100%";
+        svg.style.height = "100%";
+      }
+      options.element = markerElement;
+      const color = options.color || DEFAULT_COLOR;
+      const left = markerElement.querySelector(".left");
+      const right = markerElement.querySelector(".right");
+      if (left) left.style.fill = color;
+      if (right) right.style.fill = tinycolor(color).darken().toString();
+      options.offset = [0, -15];
+    }
+    super(options);
+  }
+};
+
+// src/lib/simplestyle.ts
+import geojsonExtent from "@mapbox/geojson-extent";
+import turfCenter from "@turf/center";
+import maplibregl2 from "maplibre-gl";
+
+// src/lib/keyring.ts
+var _apiKey, _stage, _isGeoloniaStyle;
+var Keyring = class {
+  constructor() {
+    __privateAdd(this, _apiKey, "");
+    __privateAdd(this, _stage, "dev");
+    __privateAdd(this, _isGeoloniaStyle, true);
+  }
+  get apiKey() {
+    return __privateGet(this, _apiKey);
+  }
+  get stage() {
+    return __privateGet(this, _stage);
+  }
+  get isGeoloniaStyle() {
+    return __privateGet(this, _isGeoloniaStyle);
+  }
+  set isGeoloniaStyle(value) {
+    __privateSet(this, _isGeoloniaStyle, value);
+  }
+  setApiKey(key) {
+    __privateSet(this, _apiKey, key);
+  }
+  setStage(stage) {
+    __privateSet(this, _stage, stage);
+  }
+  reset() {
+    __privateSet(this, _apiKey, "");
+    __privateSet(this, _stage, "dev");
+    __privateSet(this, _isGeoloniaStyle, true);
+  }
+  /**
+   * Check if the given style is a Geolonia style (requires API key)
+   */
+  isGeoloniaStyleCheck(style) {
+    if (!style || style === "") {
+      return true;
+    }
+    if (style.startsWith("https://cdn.geolonia.com/style/") || style.startsWith("https://api.geolonia.com/")) {
+      return true;
+    }
+    if (style.match(/^https?:\/\//)) {
+      return false;
+    }
+    if (style.endsWith(".json")) {
+      return false;
+    }
+    return true;
+  }
+};
+_apiKey = new WeakMap();
+_stage = new WeakMap();
+_isGeoloniaStyle = new WeakMap();
+var keyring = new Keyring();
+
+// src/lib/util.ts
+function isURL(str) {
+  if (str.match(/^https?:\/\//)) {
+    return str;
+  }
+  if (str.match(/^\//) || str.match(/^\.\.?/)) {
+    try {
+      return new URL(str, globalThis.location?.href).href;
+    } catch {
+      return false;
+    }
+  }
+  return false;
+}
+function isGeoloniaTilesHost(url) {
+  try {
+    const urlObj = typeof url === "string" ? new URL(url) : url;
+    return urlObj.hostname === "tileserver.geolonia.com" || urlObj.hostname.endsWith(".tiles.geolonia.com");
+  } catch {
+    return false;
+  }
+}
+function getStyle(style, options) {
+  const lang = options.lang || "en";
+  const apiKey = options.apiKey || keyring.apiKey;
+  if (keyring.isGeoloniaStyleCheck(style) && !apiKey) {
+    throw new Error("[Geolonia] API key is required to use Geolonia styles.");
+  }
+  if (!style || style === "") {
+    return `https://cdn.geolonia.com/style/geolonia/basic-v2/${lang === "ja" ? "ja" : "en"}.json`;
+  }
+  const styleUrl = isURL(style);
+  if (styleUrl) {
+    return styleUrl;
+  }
+  if (style.endsWith(".json")) {
+    try {
+      return new URL(style, globalThis.location?.href).href;
+    } catch {
+      return style;
+    }
+  }
+  return `https://cdn.geolonia.com/style/${style}/${lang === "ja" ? "ja" : "en"}.json`;
+}
+function getLang() {
+  if (typeof globalThis.navigator === "undefined") {
+    return "en";
+  }
+  const lang = globalThis.navigator.languages?.[0]?.toLowerCase() || globalThis.navigator.language?.toLowerCase();
+  return lang === "ja" || lang === "ja-jp" ? "ja" : "en";
+}
+var sessionId = "";
+function getSessionId(digit) {
+  if (sessionId) {
+    return sessionId;
+  }
+  const array = new Uint8Array(digit / 2);
+  crypto.getRandomValues(array);
+  sessionId = Array.from(
+    array,
+    (dec) => dec.toString(16).padStart(2, "0")
+  ).join("");
+  return sessionId;
+}
+function parseControlOption(value) {
+  if (typeof value === "boolean") {
+    return { enabled: value, position: void 0 };
+  }
+  if (typeof value === "string") {
+    const positions = ["top-right", "bottom-right", "bottom-left", "top-left"];
+    if (positions.includes(value.toLowerCase())) {
+      return { enabled: true, position: value.toLowerCase() };
+    }
+  }
+  return { enabled: false, position: void 0 };
+}
+function parseSimpleVector(attributeValue) {
+  if (/^(https?|geolonia):\/\//.test(attributeValue)) {
+    return attributeValue;
+  }
+  return `geolonia://tiles/custom/${attributeValue}`;
+}
+function handleRestrictedMode(map) {
+  if (!map._geolonia_restricted_mode_handled) {
+    map._geolonia_restricted_mode_handled = true;
+    const container = map.getContainer();
+    map.remove();
+    container.innerHTML = "";
+    container.classList.add("geolonia__restricted-mode-image-container");
+  }
+}
+function handleErrorMode(container) {
+  const errorContainer = document.createElement("div");
+  errorContainer.classList.add("geolonia__error-container");
+  const div = document.createElement("div");
+  const h2 = document.createElement("h2");
+  h2.textContent = "Geolonia Maps";
+  div.appendChild(h2);
+  div.classList.add("geolonia__error-message");
+  div.innerHTML += '<div class="geolonia__error-message-description">\u5730\u56F3\u306E\u521D\u671F\u5316\u306B\u5931\u6557\u3057\u307E\u3057\u305F\u3002\u7BA1\u7406\u8005\u306B\u304A\u554F\u3044\u5408\u308F\u305B\u4E0B\u3055\u3044\u3002</div>';
+  errorContainer.appendChild(div);
+  container.appendChild(errorContainer);
+}
+async function sanitizeDescription(description) {
+  const { default: sanitizeHtml } = await import("sanitize-html");
+  return sanitizeHtml(description, {
+    allowedTags: sanitizeHtml.defaults.allowedTags.concat(["img"]),
+    allowedAttributes: {
+      ...sanitizeHtml.defaults.allowedAttributes,
+      "*": ["class"]
+    }
+  });
+}
+function loadImageCompatibility(promise, callback) {
+  promise.then((response) => {
+    callback(null, response.data, {
+      cacheControl: response.cacheControl,
+      expires: response.expires
+    });
+  }).catch((error) => {
+    callback(error);
+  });
+}
+
+// src/lib/simplestyle.ts
+var textColor = "#000000";
+var textHaloColor = "#FFFFFF";
+var backgroundColor = "rgba(255, 0, 0, 0.4)";
+var strokeColor = "#FFFFFF";
+var template = {
+  type: "FeatureCollection",
+  features: []
+};
+var SimpleStyle = class {
+  constructor(geojson, options) {
+    this.callFitBounds = false;
+    this._eventHandlers = [];
+    this.setGeoJSON(geojson);
+    this.options = {
+      id: "geolonia-simple-style",
+      cluster: true,
+      heatmap: false,
+      // TODO: It should support heatmap.
+      clusterColor: "#ff0000",
+      ...options
+    };
+  }
+  updateData(geojson) {
+    this.setGeoJSON(geojson);
+    const features = this.geojson.features;
+    const polygonAndLines = features.filter(
+      (feature) => feature.geometry.type.toLowerCase() !== "point"
+    );
+    const points = features.filter(
+      (feature) => feature.geometry.type.toLowerCase() === "point"
+    );
+    this.map.getSource(this.options.id).setData({
+      type: "FeatureCollection",
+      features: polygonAndLines
+    });
+    this.map.getSource(`${this.options.id}-points`).setData({
+      type: "FeatureCollection",
+      features: points
+    });
+    return this;
+  }
+  addTo(map) {
+    this.map = map;
+    const features = this.geojson.features;
+    const polygonAndLines = features.filter(
+      (feature) => feature.geometry.type.toLowerCase() !== "point"
+    );
+    const points = features.filter(
+      (feature) => feature.geometry.type.toLowerCase() === "point"
+    );
+    this.map.addSource(this.options.id, {
+      type: "geojson",
+      data: {
+        type: "FeatureCollection",
+        features: polygonAndLines
+      }
+    });
+    this.setPolygonGeometries();
+    this.setLineGeometries();
+    this.map.addSource(`${this.options.id}-points`, {
+      type: "geojson",
+      data: {
+        type: "FeatureCollection",
+        features: points
+      },
+      cluster: this.options.cluster,
+      clusterMaxZoom: 14,
+      clusterRadius: 50
+    });
+    this.map.addLayer({
+      id: `${this.options.id}-polygon-symbol`,
+      type: "symbol",
+      source: this.options.id,
+      filter: ["==", "$type", "Polygon"],
+      paint: {
+        "text-color": ["string", ["get", "text-color"], textColor],
+        "text-halo-color": [
+          "string",
+          ["get", "text-halo-color"],
+          textHaloColor
+        ],
+        "text-halo-width": 1
+      },
+      layout: {
+        "text-field": ["get", "title"],
+        "text-font": ["Noto Sans Regular"],
+        "text-size": 12,
+        "text-max-width": 12,
+        "text-allow-overlap": false
+      }
+    });
+    this.map.addLayer({
+      id: `${this.options.id}-linestring-symbol`,
+      type: "symbol",
+      source: this.options.id,
+      filter: ["==", "$type", "LineString"],
+      paint: {
+        "text-color": ["string", ["get", "text-color"], textColor],
+        "text-halo-color": [
+          "string",
+          ["get", "text-halo-color"],
+          textHaloColor
+        ],
+        "text-halo-width": 1
+      },
+      layout: {
+        "symbol-placement": "line",
+        "text-field": ["get", "title"],
+        "text-font": ["Noto Sans Regular"],
+        "text-size": 12,
+        "text-max-width": 12,
+        "text-allow-overlap": false
+      }
+    });
+    this.setPointGeometries();
+    this.setCluster();
+    return this;
+  }
+  fitBounds(options = {}) {
+    this.callFitBounds = true;
+    const _options = {
+      duration: 3e3,
+      padding: 30,
+      ...options
+    };
+    const bounds = geojsonExtent(this.geojson);
+    if (bounds) {
+      window.requestAnimationFrame(() => {
+        this.map.fitBounds(bounds, _options);
+      });
+    }
+    return this;
+  }
+  /**
+   * Set polygon geometries.
+   */
+  setPolygonGeometries() {
+    this.map.addLayer({
+      id: `${this.options.id}-polygon`,
+      type: "fill",
+      source: this.options.id,
+      filter: ["==", "$type", "Polygon"],
+      paint: {
+        "fill-color": ["string", ["get", "fill"], backgroundColor],
+        "fill-opacity": ["number", ["get", "fill-opacity"], 1],
+        "fill-outline-color": ["string", ["get", "stroke"], strokeColor]
+      }
+    });
+    this.setPopup(this.map, `${this.options.id}-polygon`);
+  }
+  /**
+   * Set line geometries.
+   */
+  setLineGeometries() {
+    this.map.addLayer({
+      id: `${this.options.id}-linestring`,
+      type: "line",
+      source: this.options.id,
+      filter: ["==", "$type", "LineString"],
+      paint: {
+        "line-width": ["number", ["get", "stroke-width"], 2],
+        "line-color": ["string", ["get", "stroke"], backgroundColor],
+        "line-opacity": ["number", ["get", "stroke-opacity"], 1]
+      },
+      layout: {
+        "line-cap": "round",
+        "line-join": "round"
+      }
+    });
+    this.setPopup(this.map, `${this.options.id}-linestring`);
+  }
+  /**
+   * Setup point geometries.
+   */
+  setPointGeometries() {
+    this.map.addLayer({
+      id: `${this.options.id}-circle-points`,
+      type: "circle",
+      source: `${this.options.id}-points`,
+      filter: ["all", ["!has", "point_count"], ["!has", "marker-symbol"]],
+      paint: {
+        "circle-radius": [
+          "case",
+          ["==", "small", ["get", "marker-size"]],
+          7,
+          ["==", "large", ["get", "marker-size"]],
+          13,
+          9
+        ],
+        "circle-color": ["string", ["get", "marker-color"], backgroundColor],
+        "circle-opacity": ["number", ["get", "fill-opacity"], 1],
+        "circle-stroke-width": ["number", ["get", "stroke-width"], 1],
+        "circle-stroke-color": ["string", ["get", "stroke"], strokeColor],
+        "circle-stroke-opacity": ["number", ["get", "stroke-opacity"], 1]
+      }
+    });
+    this.map.addLayer({
+      id: `${this.options.id}-symbol-points`,
+      type: "symbol",
+      source: `${this.options.id}-points`,
+      filter: ["!", ["has", "point_count"]],
+      paint: {
+        "text-color": ["string", ["get", "text-color"], textColor],
+        "text-halo-color": [
+          "string",
+          ["get", "text-halo-color"],
+          textHaloColor
+        ],
+        "text-halo-width": 1
+      },
+      layout: {
+        "icon-image": ["get", "marker-symbol"],
+        "text-field": ["get", "title"],
+        "text-font": ["Noto Sans Regular"],
+        "text-size": 12,
+        "text-max-width": 12,
+        "text-allow-overlap": true,
+        "icon-allow-overlap": true,
+        "text-variable-anchor": ["top", "bottom", "left", "right"],
+        "text-radial-offset": [
+          "case",
+          ["==", "small", ["get", "marker-size"]],
+          1,
+          ["==", "large", ["get", "marker-size"]],
+          1.6,
+          1.2
+        ]
+      }
+    });
+    this.setPopup(this.map, `${this.options.id}-circle-points`);
+    this.setPopup(this.map, `${this.options.id}-symbol-points`);
+  }
+  async setPopup(map, source) {
+    const clickHandler = async (e) => {
+      const center = turfCenter(e.features[0]).geometry.coordinates;
+      const description = e.features[0].properties.description;
+      if (description) {
+        const sanitizedDescription = await sanitizeDescription(description);
+        new maplibregl2.Popup().setLngLat(center).setHTML(sanitizedDescription).addTo(map);
+      }
+    };
+    const mouseEnterHandler = (e) => {
+      if (e.features[0].properties.description) {
+        map.getCanvas().style.cursor = "pointer";
+      }
+    };
+    const mouseLeaveHandler = () => {
+      map.getCanvas().style.cursor = "";
+    };
+    map.on("click", source, clickHandler);
+    map.on("mouseenter", source, mouseEnterHandler);
+    map.on("mouseleave", source, mouseLeaveHandler);
+    this._eventHandlers.push(
+      { event: "click", layer: source, handler: clickHandler },
+      { event: "mouseenter", layer: source, handler: mouseEnterHandler },
+      { event: "mouseleave", layer: source, handler: mouseLeaveHandler }
+    );
+  }
+  /**
+   * Setup cluster markers
+   */
+  setCluster() {
+    this.map.addLayer({
+      id: `${this.options.id}-clusters`,
+      type: "circle",
+      source: `${this.options.id}-points`,
+      filter: ["has", "point_count"],
+      paint: {
+        "circle-radius": 20,
+        "circle-color": this.options.clusterColor,
+        "circle-opacity": 1
+      }
+    });
+    this.map.addLayer({
+      id: `${this.options.id}-cluster-count`,
+      type: "symbol",
+      source: `${this.options.id}-points`,
+      filter: ["has", "point_count"],
+      layout: {
+        "text-field": "{point_count_abbreviated}",
+        "text-size": 14,
+        "text-font": ["Noto Sans Regular"]
+      }
+    });
+    const clusterLayer = `${this.options.id}-clusters`;
+    const clusterClickHandler = async (e) => {
+      const features = this.map.queryRenderedFeatures(e.point, {
+        layers: [clusterLayer]
+      });
+      const clusterId = features[0].properties.cluster_id;
+      const zoom = await this.map.getSource(`${this.options.id}-points`).getClusterExpansionZoom(clusterId);
+      this.map.easeTo({
+        center: features[0].geometry.coordinates,
+        zoom
+      });
+    };
+    const clusterEnterHandler = () => {
+      this.map.getCanvas().style.cursor = "pointer";
+    };
+    const clusterLeaveHandler = () => {
+      this.map.getCanvas().style.cursor = "";
+    };
+    this.map.on("click", clusterLayer, clusterClickHandler);
+    this.map.on("mouseenter", clusterLayer, clusterEnterHandler);
+    this.map.on("mouseleave", clusterLayer, clusterLeaveHandler);
+    this._eventHandlers.push(
+      { event: "click", layer: clusterLayer, handler: clusterClickHandler },
+      {
+        event: "mouseenter",
+        layer: clusterLayer,
+        handler: clusterEnterHandler
+      },
+      {
+        event: "mouseleave",
+        layer: clusterLayer,
+        handler: clusterLeaveHandler
+      }
+    );
+  }
+  remove() {
+    if (!this.map) return this;
+    const id = this.options.id;
+    for (const { event, layer, handler } of this._eventHandlers) {
+      this.map.off(event, layer, handler);
+    }
+    this._eventHandlers = [];
+    const layerIds = [
+      `${id}-polygon-symbol`,
+      `${id}-linestring-symbol`,
+      `${id}-circle-points`,
+      `${id}-symbol-points`,
+      `${id}-polygon`,
+      `${id}-linestring`,
+      `${id}-clusters`,
+      `${id}-cluster-count`
+    ];
+    for (const layerId of layerIds) {
+      if (this.map.getLayer(layerId)) {
+        this.map.removeLayer(layerId);
+      }
+    }
+    for (const sourceId of [id, `${id}-points`]) {
+      if (this.map.getSource(sourceId)) {
+        this.map.removeSource(sourceId);
+      }
+    }
+    this.map.getCanvas().style.cursor = "";
+    return this;
+  }
+  setGeoJSON(geojson) {
+    if (typeof geojson === "string" && isURL(geojson)) {
+      this.geojson = template;
+      const fetchGeoJSON = async () => {
+        try {
+          const response = await window.fetch(geojson);
+          const data = response.ok ? await response.json() : {};
+          this.geojson = data;
+          this.updateData(data);
+          if (this.callFitBounds) {
+            this.fitBounds();
+            this.callFitBounds = false;
+          }
+        } catch (error) {
+          console.error("[Geolonia] Failed to load GeoJSON:", error);
+        }
+      };
+      this._loadingPromise = fetchGeoJSON();
+    } else {
+      this.geojson = geojson;
+    }
+  }
+};
+
+// src/lib/simplestyle-vector.ts
+import turfCenter2 from "@turf/center";
+import maplibregl3 from "maplibre-gl";
+var textColor2 = "#000000";
+var textHaloColor2 = "#FFFFFF";
+var backgroundColor2 = "rgba(255, 0, 0, 0.4)";
+var strokeColor2 = "#FFFFFF";
+var SimpleStyleVector = class {
+  constructor(url) {
+    this.url = url;
+    this.sourceName = "vt-geolonia-simple-style";
+  }
+  /* eslint-disable @typescript-eslint/no-explicit-any */
+  addTo(map) {
+    const container = map.getContainer();
+    if (!container.dataset || !container.dataset.lng && !container.dataset.lat) {
+      let initialZoomDone = false;
+      map.on("sourcedata", (event) => {
+        if (event.sourceId !== this.sourceName) {
+          return;
+        }
+        const source = map.getSource(event.sourceId);
+        const isLoaded = source && source.loaded();
+        if (isLoaded !== true) {
+          return;
+        }
+        if (initialZoomDone) {
+          return;
+        }
+        initialZoomDone = true;
+        map.fitBounds(source.bounds, {
+          duration: 0,
+          padding: 30
+        });
+      });
+    }
+    map.addSource(this.sourceName, {
+      type: "vector",
+      url: this.url
+    });
+    this.setPolygonGeometries(map);
+    this.setLineGeometries(map);
+    map.addLayer({
+      id: "vt-geolonia-simple-style-polygon-symbol",
+      type: "symbol",
+      source: this.sourceName,
+      "source-layer": "g-simplestyle-v1",
+      filter: ["==", "$type", "Polygon"],
+      paint: {
+        "text-color": ["string", ["get", "text-color"], textColor2],
+        "text-halo-color": [
+          "string",
+          ["get", "text-halo-color"],
+          textHaloColor2
+        ],
+        "text-halo-width": 1
+      },
+      layout: {
+        "text-field": ["get", "title"],
+        "text-font": ["Noto Sans Regular"],
+        "text-size": 12,
+        "text-max-width": 12,
+        "text-allow-overlap": false
+      }
+    });
+    map.addLayer({
+      id: "vt-geolonia-simple-style-linestring-symbol",
+      type: "symbol",
+      source: this.sourceName,
+      "source-layer": "g-simplestyle-v1",
+      filter: ["==", "$type", "LineString"],
+      paint: {
+        "text-color": ["string", ["get", "text-color"], textColor2],
+        "text-halo-color": [
+          "string",
+          ["get", "text-halo-color"],
+          textHaloColor2
+        ],
+        "text-halo-width": 1
+      },
+      layout: {
+        "symbol-placement": "line",
+        "text-field": ["get", "title"],
+        "text-font": ["Noto Sans Regular"],
+        "text-size": 12,
+        "text-max-width": 12,
+        "text-allow-overlap": false
+      }
+    });
+    this.setPointGeometries(map);
+  }
+  /**
+   * Set polygon geometries.
+   *
+   * @param map
+   */
+  setPolygonGeometries(map) {
+    map.addLayer({
+      id: "vt-geolonia-simple-style-polygon",
+      type: "fill",
+      source: this.sourceName,
+      "source-layer": "g-simplestyle-v1",
+      filter: ["==", "$type", "Polygon"],
+      paint: {
+        "fill-color": ["string", ["get", "fill"], backgroundColor2],
+        "fill-opacity": ["number", ["get", "fill-opacity"], 1],
+        "fill-outline-color": ["string", ["get", "stroke"], strokeColor2]
+      }
+    });
+    this.setPopup(map, "vt-geolonia-simple-style-polygon");
+  }
+  /**
+   * Set line geometries.
+   *
+   * @param map
+   */
+  setLineGeometries(map) {
+    map.addLayer({
+      id: "vt-geolonia-simple-style-linestring",
+      type: "line",
+      source: this.sourceName,
+      "source-layer": "g-simplestyle-v1",
+      filter: ["==", "$type", "LineString"],
+      paint: {
+        "line-width": ["number", ["get", "stroke-width"], 2],
+        "line-color": ["string", ["get", "stroke"], backgroundColor2],
+        "line-opacity": ["number", ["get", "stroke-opacity"], 1]
+      },
+      layout: {
+        "line-cap": "round",
+        "line-join": "round"
+      }
+    });
+    this.setPopup(map, "vt-geolonia-simple-style-linestring");
+  }
+  /**
+   * Setup point geometries.
+   *
+   * @param map
+   */
+  setPointGeometries(map) {
+    map.addLayer({
+      id: "vt-circle-simple-style-points",
+      type: "circle",
+      source: this.sourceName,
+      "source-layer": "g-simplestyle-v1",
+      filter: ["all", ["==", "$type", "Point"], ["!has", "marker-symbol"]],
+      paint: {
+        "circle-radius": [
+          "case",
+          ["==", "small", ["get", "marker-size"]],
+          7,
+          ["==", "large", ["get", "marker-size"]],
+          13,
+          9
+        ],
+        "circle-color": ["string", ["get", "marker-color"], backgroundColor2],
+        "circle-opacity": ["number", ["get", "fill-opacity"], 1],
+        "circle-stroke-width": ["number", ["get", "stroke-width"], 1],
+        "circle-stroke-color": ["string", ["get", "stroke"], strokeColor2],
+        "circle-stroke-opacity": ["number", ["get", "stroke-opacity"], 1]
+      }
+    });
+    map.addLayer({
+      id: "vt-geolonia-simple-style-points",
+      type: "symbol",
+      source: this.sourceName,
+      "source-layer": "g-simplestyle-v1",
+      filter: ["==", "$type", "Point"],
+      paint: {
+        "text-color": ["string", ["get", "text-color"], textColor2],
+        "text-halo-color": [
+          "string",
+          ["get", "text-halo-color"],
+          textHaloColor2
+        ],
+        "text-halo-width": 1
+      },
+      layout: {
+        "icon-image": ["get", "marker-symbol"],
+        "text-field": ["get", "title"],
+        "text-font": ["Noto Sans Regular"],
+        "text-size": 12,
+        "text-anchor": "top",
+        "text-max-width": 12,
+        "text-offset": [
+          "case",
+          ["==", "small", ["get", "marker-size"]],
+          ["literal", [0, 1]],
+          ["==", "large", ["get", "marker-size"]],
+          ["literal", [0, 1.6]],
+          ["literal", [0, 1.2]]
+        ],
+        "text-allow-overlap": false
+      }
+    });
+    this.setPopup(map, "vt-circle-simple-style-points");
+    this.setPopup(map, "vt-geolonia-simple-style-points");
+  }
+  async setPopup(map, source) {
+    map.on("click", source, async (e) => {
+      const center = turfCenter2(e.features[0]).geometry.coordinates;
+      const description = e.features[0].properties.description;
+      if (description) {
+        const sanitizedDescription = await sanitizeDescription(description);
+        new maplibregl3.Popup().setLngLat(center).setHTML(sanitizedDescription).addTo(map);
+      }
+    });
+    map.on("mouseenter", source, (e) => {
+      if (e.features[0].properties.description) {
+        map.getCanvas().style.cursor = "pointer";
+      }
+    });
+    map.on("mouseleave", source, () => {
+      map.getCanvas().style.cursor = "";
+    });
+  }
+};
+var simplestyle_vector_default = SimpleStyleVector;
+
+// src/lib/geolonia-map.ts
+var pmtilesRegistered = false;
+function ensurePMTiles() {
+  if (pmtilesRegistered) return;
+  pmtilesRegistered = true;
+  const protocol = new Protocol();
+  maplibregl4.addProtocol("pmtiles", protocol.tile);
+}
+var GeoloniaMap = class extends maplibregl4.Map {
+  constructor(options) {
+    ensurePMTiles();
+    if (options.apiKey) {
+      keyring.setApiKey(options.apiKey);
+    }
+    if (options.stage) {
+      keyring.setStage(options.stage);
+    }
+    const lang = options.lang === "auto" || !options.lang ? getLang() : options.lang;
+    const styleName = options.style || "geolonia/basic-v2";
+    keyring.isGeoloniaStyle = keyring.isGeoloniaStyleCheck(styleName);
+    const resolvedStyle = getStyle(styleName, {
+      lang,
+      apiKey: options.apiKey || keyring.apiKey
+    });
+    const container = typeof options.container === "string" ? document.querySelector(options.container) || document.getElementById(options.container) : options.container;
+    if (!container) {
+      throw new Error(
+        `[Geolonia] No HTML elements found. Please ensure the map container element exists.`
+      );
+    }
+    if (container.geoloniaMap) {
+      return container.geoloniaMap;
+    }
+    const apiKey = options.apiKey || keyring.apiKey;
+    const stage = options.stage || keyring.stage;
+    const apiUrl = `https://api.geolonia.com/${stage}`;
+    const sessionId2 = getSessionId(40);
+    const sourcesUrl = new URL(`${apiUrl}/sources`);
+    sourcesUrl.searchParams.set("key", apiKey);
+    sourcesUrl.searchParams.set("sessionId", sessionId2);
+    const userTransformRequest = options.transformRequest;
+    const transformRequest = (url, resourceType) => {
+      if (resourceType === "Source" && url.startsWith("https://api.geolonia.com")) {
+        return { url: sourcesUrl.toString() };
+      }
+      let transformedUrl = url;
+      if (url.startsWith("geolonia://")) {
+        const tilesMatch = url.match(
+          /^geolonia:\/\/tiles\/(?<username>.+)\/(?<customtileId>.+)/
+        );
+        if (tilesMatch?.groups) {
+          transformedUrl = `https://tileserver.geolonia.com/customtiles/${tilesMatch.groups.customtileId}/tiles.json`;
+        }
+      }
+      const transformedUrlObj = new URL(transformedUrl);
+      const geoloniaTilesHost = isGeoloniaTilesHost(transformedUrlObj);
+      if (resourceType === "Source" && geoloniaTilesHost) {
+        if (stage === "dev" && transformedUrlObj.hostname === "tileserver.geolonia.com") {
+          transformedUrlObj.hostname = "tileserver-dev.geolonia.com";
+        }
+        transformedUrlObj.searchParams.set("sessionId", sessionId2);
+        transformedUrlObj.searchParams.set("key", apiKey);
+        return { url: transformedUrlObj.toString() };
+      }
+      if ((resourceType === "SpriteJSON" || resourceType === "SpriteImage") && transformedUrl.match(
+        /^https:\/\/api\.geolonia\.com\/(dev|v1)\/sprites\//
+      )) {
+        const pathParts = transformedUrlObj.pathname.split("/");
+        pathParts[1] = stage;
+        transformedUrlObj.pathname = pathParts.join("/");
+        transformedUrlObj.searchParams.set("key", apiKey);
+        return { url: transformedUrlObj.toString() };
+      }
+      if (typeof userTransformRequest === "function") {
+        return userTransformRequest(transformedUrl, resourceType);
+      }
+      return void 0;
+    };
+    let loading;
+    const showLoader = options.loader !== false;
+    if (showLoader) {
+      loading = document.createElement("div");
+      loading.className = "loading-geolonia-map";
+      loading.innerHTML = `<div class="lds-grid"><div></div><div></div><div></div>
+          <div></div><div></div><div></div><div></div><div></div><div></div></div>`;
+      container.appendChild(loading);
+    }
+    const mapOptions = {
+      ...options,
+      container,
+      style: resolvedStyle,
+      hash: options.hash ?? false,
+      localIdeographFontFamily: options.localIdeographFontFamily ?? "sans-serif",
+      attributionControl: false,
+      transformRequest
+    };
+    for (const key of [
+      "apiKey",
+      "stage",
+      "lang",
+      "marker",
+      "markerColor",
+      "openPopup",
+      "customMarker",
+      "customMarkerOffset",
+      "loader",
+      "gestureHandling",
+      "navigationControl",
+      "geolocateControl",
+      "fullscreenControl",
+      "scaleControl",
+      "geoloniaControl",
+      "geojson",
+      "cluster",
+      "clusterColor",
+      "simpleVector",
+      "3d"
+    ]) {
+      delete mapOptions[key];
+    }
+    try {
+      super(mapOptions);
+    } catch (error) {
+      handleErrorMode(container);
+      throw error;
+    }
+    this.geoloniaSourcesUrl = sourcesUrl;
+    this.__styleExtensionLoadRequired = true;
+    const geoloniaCtrl = parseControlOption(options.geoloniaControl ?? true);
+    this.addControl(
+      new GeoloniaControl(),
+      geoloniaCtrl.position
+    );
+    this.addControl(new attribution_default(), "bottom-right");
+    const fullscreen = parseControlOption(options.fullscreenControl ?? false);
+    if (fullscreen.enabled) {
+      this.addControl(
+        new FullscreenControl(),
+        fullscreen.position
+      );
+    }
+    const nav = parseControlOption(options.navigationControl ?? true);
+    if (nav.enabled) {
+      this.addControl(new NavigationControl(), nav.position);
+    }
+    const geolocate = parseControlOption(options.geolocateControl ?? false);
+    if (geolocate.enabled) {
+      this.addControl(
+        new GeolocateControl({}),
+        geolocate.position
+      );
+    }
+    const scale = parseControlOption(options.scaleControl ?? false);
+    if (scale.enabled) {
+      this.addControl(new ScaleControl({}), scale.position);
+    }
+    this.on("load", (event) => {
+      const map = event.target;
+      if (loading) {
+        try {
+          container.removeChild(loading);
+        } catch {
+        }
+      }
+      if (options.gestureHandling !== false) {
+        import("@geolonia/mbgl-gesture-handling").then(({ default: GestureHandling }) => {
+          const body = document.body;
+          const html = document.documentElement;
+          const isScrollable = body.scrollHeight > body.clientHeight || html.scrollHeight > html.clientHeight;
+          if (isScrollable) {
+            new GestureHandling({ lang }).addTo(map);
+          }
+        }).catch(() => {
+        });
+      }
+      if (options.marker && options.center) {
+        const c = options.center;
+        const center = Array.isArray(c) ? [c[0], c[1]] : "lng" in c ? [c.lng, c.lat] : [c.lon, c.lat];
+        let marker;
+        if (options.customMarker) {
+          const customEl = document.querySelector(
+            options.customMarker
+          );
+          if (customEl) {
+            customEl.style.display = "block";
+            marker = new GeoloniaMarker({
+              element: customEl,
+              offset: options.customMarkerOffset || [0, 0]
+            }).setLngLat(center).addTo(map);
+          } else {
+            marker = new GeoloniaMarker({ color: options.markerColor }).setLngLat(center).addTo(map);
+          }
+        } else {
+          marker = new GeoloniaMarker({ color: options.markerColor }).setLngLat(center).addTo(map);
+        }
+        const content = container.dataset?.popupContent;
+        if (content) {
+          const popup = new Popup({ offset: [0, -25] }).setHTML(content);
+          marker.setPopup(popup);
+          if (options.openPopup) {
+            marker.togglePopup();
+          }
+        } else if (options.openPopup) {
+        }
+        marker.getElement().classList.add("geolonia-clickable-marker");
+      }
+    });
+    this.on("styledata", async () => {
+      if (!this.__styleExtensionLoadRequired) {
+        return;
+      }
+      this.__styleExtensionLoadRequired = false;
+      if (options.simpleVector) {
+        const url = parseSimpleVector(options.simpleVector);
+        new simplestyle_vector_default(url).addTo(this);
+      }
+      if (options.geojson) {
+        const ss = new SimpleStyle(options.geojson, {
+          cluster: options.cluster !== false,
+          clusterColor: options.clusterColor || "#ff0000"
+        });
+        ss.addTo(this);
+        if (!options.center) {
+          ss.fitBounds();
+        }
+      }
+      if (options["3d"] === true) {
+        const style = this.getStyle();
+        if (style?.layers) {
+          for (const layer of style.layers) {
+            const metadata = layer.metadata;
+            if (metadata?.["visible-on-3d"]) {
+              this.setLayoutProperty(layer.id, "visibility", "visible");
+            }
+            if (metadata?.["hide-on-3d"]) {
+              this.setLayoutProperty(layer.id, "visibility", "none");
+            }
+          }
+        }
+      }
+    });
+    this.on("error", async (error) => {
+      if (error.error && error.error.status === 402) {
+        handleRestrictedMode(this);
+      }
+    });
+    container.geoloniaMap = this;
+    return this;
+  }
+  setStyle(style, options = {}) {
+    if (style !== null && typeof style === "string") {
+      style = getStyle(style, { lang: getLang(), apiKey: keyring.apiKey });
+    }
+    this.__styleExtensionLoadRequired = true;
+    super.setStyle.call(this, style, options);
+    return this;
+  }
+  remove() {
+    const container = this.getContainer();
+    super.remove.call(this);
+    delete container.geoloniaMap;
+  }
+  loadImage(url, callback) {
+    const promise = super.loadImage(url);
+    if (callback) {
+      loadImageCompatibility(promise, callback);
+    } else {
+      return promise;
+    }
+  }
+};
+
+// src/version.ts
+var VERSION = "0.1.0";
+export {
+  attribution_default as CustomAttributionControl,
+  GeoloniaControl,
+  GeoloniaMap,
+  GeoloniaMarker,
+  SimpleStyle,
+  simplestyle_vector_default as SimpleStyleVector,
+  VERSION as coreVersion,
+  getLang,
+  getStyle,
+  isGeoloniaTilesHost,
+  keyring
+};

--- a/public/maps-core/style.css
+++ b/public/maps-core/style.css
@@ -1,0 +1,166 @@
+.geolonia-clickable-marker {
+  cursor: pointer;
+}
+
+/* Make fullscreen mode works with ie11 */
+.geolonia:-ms-fullscreen {
+  width: 100%;
+  height: 100%;
+}
+
+/**
+ * Styles for loading effect.
+ */
+.loading-geolonia-map {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  background-color: rgba(255, 255, 255, 0.5);
+  z-index: 9999;
+  justify-content: center;
+  align-items: center;
+  display: flex;
+}
+
+.loading-geolonia-map .lds-grid {
+  display: inline-block;
+  position: relative;
+  width: 80px;
+  height: 80px;
+}
+
+.loading-geolonia-map .lds-grid div {
+  position: absolute;
+  width: 16px;
+  height: 16px;
+  border-radius: 50%;
+  background: #999999;
+  animation: lds-grid 1.2s linear infinite;
+}
+
+.loading-geolonia-map .lds-grid div:nth-child(1) {
+  top: 8px;
+  left: 8px;
+  animation-delay: 0s;
+}
+
+.loading-geolonia-map .lds-grid div:nth-child(2) {
+  top: 8px;
+  left: 32px;
+  animation-delay: -0.4s;
+}
+
+.loading-geolonia-map .lds-grid div:nth-child(3) {
+  top: 8px;
+  left: 56px;
+  animation-delay: -0.8s;
+}
+
+.loading-geolonia-map .lds-grid div:nth-child(4) {
+  top: 32px;
+  left: 8px;
+  animation-delay: -0.4s;
+}
+
+.loading-geolonia-map .lds-grid div:nth-child(5) {
+  top: 32px;
+  left: 32px;
+  animation-delay: -0.8s;
+}
+
+.loading-geolonia-map .lds-grid div:nth-child(6) {
+  top: 32px;
+  left: 56px;
+  animation-delay: -1.2s;
+}
+
+.loading-geolonia-map .lds-grid div:nth-child(7) {
+  top: 56px;
+  left: 8px;
+  animation-delay: -0.8s;
+}
+
+.loading-geolonia-map .lds-grid div:nth-child(8) {
+  top: 56px;
+  left: 32px;
+  animation-delay: -1.2s;
+}
+
+.loading-geolonia-map .lds-grid div:nth-child(9) {
+  top: 56px;
+  left: 56px;
+  animation-delay: -1.6s;
+}
+
+@keyframes lds-grid {
+  0%,
+  100% {
+    opacity: 1;
+  }
+  50% {
+    opacity: 0.5;
+  }
+}
+
+/* Style for restricted mode */
+.geolonia__restricted-mode-image-container {
+  background-image: url("https://geolonia.github.io/embed/restricted.jpg");
+  background-position: center center;
+  background-size: cover;
+}
+
+/* Style for error message */
+.geolonia__error-container {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  height: 100%;
+  width: 100%;
+  background-color: #dedede;
+  z-index: 9999;
+  position: absolute;
+}
+
+.geolonia__error-message {
+  max-width: 300px;
+  background-color: #ffffff;
+  margin: 10px;
+  padding: 0.75rem 1.25rem;
+  border-radius: 6px;
+  position: absolute;
+  z-index: 99999;
+  word-wrap: break-word;
+  box-shadow: 0 4px 10px #0000001a;
+}
+
+.geolonia__error-message-description {
+  margin: 15px 0;
+}
+
+/* CSS for Attribution */
+/* Fix: https://github.com/geolonia/embed/issues/291 */
+.maplibregl-map {
+  display: block !important;
+}
+
+.maplibregl-ctrl-attrib-inner {
+  display: block !important;
+}
+
+.maplibregl-ctrl-attrib.maplibregl-compact .maplibregl-ctrl-attrib-inner {
+  display: none !important;
+}
+
+.maplibregl-ctrl-attrib.maplibregl-compact-show .maplibregl-ctrl-attrib-inner,
+.maplibregl-ctrl-attrib.maplibregl-compact .maplibregl-ctrl-attrib-button {
+  display: block !important;
+}
+/* End: CSS for Attribution */
+
+@media print {
+  .maplibregl-control-container button {
+    display: none;
+  }
+}


### PR DESCRIPTION
## Summary
- `@geolonia/maps-core` の UMD バンドルを CDN で配信するためのビルドスクリプトを追加
- UMD は GitHub Releases から取得する方式（npm tarball には含まれない）
- CSS は npm パッケージ（`--ignore-scripts`）から取得

## Blocker
- https://github.com/geolonia/maps-core/pull/2

## ビルドスクリプトの動作
1. `gh release download` で `maps-core-umd.tar.gz` を GitHub Releases から取得
2. `public/maps-core/` に展開
3. CSS は `npm install @geolonia/maps-core --ignore-scripts` で取得しコピー
4. `MAPS_CORE_VERSION` 環境変数でタグ指定可能（デフォルト: latest）

## 配信ファイル
- `public/maps-core/maps-core.umd.cjs` (UMD, ~1.3 MB)
- `public/maps-core/style.css` (3 KB)

## Test plan
- [ ] `npm run build:maps-core` でビルド成功を確認
- [ ] `public/maps-core/` に UMD と CSS が配置されることを確認
- [ ] `MAPS_CORE_VERSION=v0.2.0` で特定バージョンを取得できることを確認