### PR TITLE
Update GitHub Actions to latest versions

### DIFF
--- a/.github/workflows/cdn_deploy.yml
+++ b/.github/workflows/cdn_deploy.yml
@@ -16,15 +16,15 @@ jobs:
       contents: read
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
       - name: Restore timestamps
-        uses: chetan/git-restore-mtime-action@v1
+        uses: chetan/git-restore-mtime-action@v2
 
       - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v1
+        uses: aws-actions/configure-aws-credentials@v6
         with:
           aws-region: ap-northeast-1
           role-to-assume: arn:aws:iam::762706324393:role/github-actions-cdn-geolonia-deploy

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -8,25 +8,13 @@ jobs:
   comment:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v6
 
-      - name: Use Node.js 18
-        uses: actions/setup-node@v3
+      - name: Use Node.js 22
+        uses: actions/setup-node@v6
         with:
-          node-version: 18
-
-      - name: Get npm cache directory
-        id: npm-cache-dir
-        shell: bash
-        run: echo "dir=$(npm config get cache)" >> ${GITHUB_OUTPUT}
-
-      - uses: actions/cache@v3
-        id: npm-cache # use this to check for `cache-hit` ==> if: steps.npm-cache.outputs.cache-hit != 'true'
-        with:
-          path: ${{ steps.npm-cache-dir.outputs.dir }}
-          key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
-          restore-keys: |
-            ${{ runner.os }}-node-
+          node-version: '22.x'
+          cache: 'npm'
 
       - run: npm ci
 
@@ -36,20 +24,17 @@ jobs:
           BRANCH_NAME: ${{ github.head_ref }}
         run: |
           COMMENT=$(node bin/compare-styles.mjs $BASE_BRANCH $BRANCH_NAME)
-          COMMENT="${COMMENT//'%'/'%25'}"
-          COMMENT="${COMMENT//$'\n'/'%0A'}"
-          COMMENT="${COMMENT//$'\r'/'%0D'}"
-          echo ::set-output name=comment::$COMMENT
+          echo "comment<<EOF" >> $GITHUB_OUTPUT
+          echo "$COMMENT" >> $GITHUB_OUTPUT
+          echo "EOF" >> $GITHUB_OUTPUT
 
       - name: Post comment
-        uses: actions/github-script@v4
-        if: github.event_name == 'pull_request'
+        uses: actions/github-script@v8
+        if: github.event_name == 'pull_request' && steps.create_comment_diff.outputs.comment
         env:
           POSTING_COMMENT_BODY: ${{ steps.create_comment_diff.outputs.comment }}
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
-            const { issue: { number: issue_number }, repo: { owner, repo }  } = context;
-            process.env.POSTING_COMMENT_BODY ?
-              github.issues.createComment({ issue_number, owner, repo, body: process.env.POSTING_COMMENT_BODY }) :
-              console.log('No diffs.');
+            const { issue: { number: issue_number }, repo: { owner, repo } } = context;
+            await github.rest.issues.createComment({ issue_number, owner, repo, body: process.env.POSTING_COMMENT_BODY });


### PR DESCRIPTION
## Summary
- CI で使用している GitHub Actions を最新メジャーバージョンに更新
- 廃止済みの構文・パターンを修正

## 変更一覧

### cdn_deploy.yml
| Action | Before | After |
|--------|--------|-------|
| `actions/checkout` | v3 | v6 |
| `chetan/git-restore-mtime-action` | v1 | v2 |
| `aws-actions/configure-aws-credentials` | v1 | v6 |

### pr.yml
| Action | Before | After |
|--------|--------|-------|
| `actions/checkout` | v3 | v6 |
| `actions/setup-node` | v3 | v6 |
| `actions/cache` | v3 | 削除（setup-node の `cache: 'npm'` で代替） |
| `actions/github-script` | v4 | v8 |
| Node.js | 18 | 22 |
| `::set-output` | 廃止済み | `$GITHUB_OUTPUT` + EOF デリミタ |

## Test plan
- [ ] master への push で cdn_deploy.yml が正常に動作すること
- [ ] PR 作成時に pr.yml のスタイル差分コメントが正常に投稿されること

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **Chores**
  * CI/CDパイプラインのアクション依存関係を新しいバージョンに更新しました。
  * Node.jsランタイムとキャッシング処理を改善しました。
  * プルリクエスト処理フローの出力形式を最適化しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->